### PR TITLE
Fix hello-world dependencies after move from monorepo

### DIFF
--- a/examples/hello-world/deps.edn
+++ b/examples/hello-world/deps.edn
@@ -1,12 +1,12 @@
 {:paths ["src/main" "resources"]
  
  :deps {
-        starfederation.datastar/sdk  {:local/root "../../../sdk/clojure/sdk"}
-        starfederation.datastar/ring {:local/root "../../../sdk/clojure/adapter-ring"}
-        ring/ring-jetty-adapter      {:mvn/version "1.13.0"}
-        metosin/reitit               {:mvn/version "0.7.2"}
-        dev.onionpancakes/chassis    {:mvn/version "1.0.365"}
-        com.cnuernber/charred        {:mvn/version "1.034"}}
+        dev.data-star.clojure/sdk  {:local/root "../../sdk"}
+        dev.data-star.clojure/ring {:local/root "../../sdk-adapter-ring"}
+        ring/ring-jetty-adapter    {:mvn/version "1.13.0"}
+        metosin/reitit             {:mvn/version "0.7.2"}
+        dev.onionpancakes/chassis  {:mvn/version "1.0.365"}
+        com.cnuernber/charred      {:mvn/version "1.034"}}
  
  :aliases
  {:repl {:extra-paths ["src/dev"]


### PR DESCRIPTION
I believe I found more leftovers after the move from the monorepo :)

Before these chages, `clojure -M -m example.main` crashed. After changes, I see the SDK demo running:

<img width="1093" height="632" alt="image" src="https://github.com/user-attachments/assets/410516dc-f58e-4520-9a9a-175706123d0f" />
