### PR TITLE
Add http-kit example

### DIFF
--- a/examples/hello-httpkit/README.md
+++ b/examples/hello-httpkit/README.md
@@ -1,6 +1,15 @@
 # A Datastar + http-kit starter
 
-For development,
+## Running the example
 
-1. Start a REPL
-2. Run the `start!` function in `hello_httpkit.clj`.
+- repl:
+
+```
+clojure -M:repl -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+```
+
+- main:
+
+```
+clojure -M -m hello-httpkit
+```

--- a/examples/hello-httpkit/README.md
+++ b/examples/hello-httpkit/README.md
@@ -1,0 +1,6 @@
+# A Datastar + http-kit starter
+
+For development,
+
+1. Start a REPL
+2. Run the `start!` function in `hello_httpkit.clj`.

--- a/examples/hello-httpkit/deps.edn
+++ b/examples/hello-httpkit/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {com.cnuernber/charred {:mvn/version "1.034"}
+        dev.data-star.clojure/http-kit {:local/root "../../sdk-adapter-http-kit"}
+        dev.data-star.clojure/sdk {:local/root "../../sdk"}
+        dev.onionpancakes/chassis {:mvn/version "1.0.365"}
+        http-kit/http-kit {:mvn/version "2.8.1"}
+        metosin/reitit {:mvn/version "0.7.2"}}}

--- a/examples/hello-httpkit/deps.edn
+++ b/examples/hello-httpkit/deps.edn
@@ -4,4 +4,8 @@
         dev.data-star.clojure/sdk {:local/root "../../sdk"}
         dev.onionpancakes/chassis {:mvn/version "1.0.365"}
         http-kit/http-kit {:mvn/version "2.8.1"}
-        metosin/reitit {:mvn/version "0.7.2"}}}
+        metosin/reitit {:mvn/version "0.7.2"}}
+ :aliases
+ {:repl {:extra-deps {org.clojure/clojure         {:mvn/version "1.12.0"}
+                      nrepl/nrepl                 {:mvn/version "1.3.0"}
+                      cider/cider-nrepl           {:mvn/version "0.50.2"}}}}}

--- a/examples/hello-httpkit/resources/hello-world.html
+++ b/examples/hello-httpkit/resources/hello-world.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Datastar SDK Demo</title>
+    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
+</head>
+<body class="bg-white dark:bg-gray-900 text-lg max-w-xl mx-auto my-16">
+    <div data-signals-delay="400" class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg px-6 py-8 ring shadow-xl ring-gray-900/5 space-y-2">
+        <div class="flex justify-between items-center">
+            <h1 class="text-gray-900 dark:text-white text-3xl font-semibold">
+                Datastar SDK Demo
+            </h1>
+            <img src="https://data-star.dev/static/images/rocket-64x64.png" alt="Rocket" width="64" height="64"/>
+        </div>
+        <p class="mt-2">
+            SSE events will be streamed from the backend to the frontend.
+        </p>
+        <div class="space-x-2">
+            <label for="delay">
+                Delay in milliseconds
+            </label>
+            <input data-bind-delay id="delay" type="number" step="100" min="0" class="w-36 rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-sky-500 focus:outline focus:outline-sky-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-800/20" />
+        </div>
+        <button data-on-click="@get(&#39;/hello-world&#39;)" class="rounded-md bg-sky-500 px-5 py-2.5 leading-5 font-semibold text-white hover:bg-sky-700 hover:text-gray-100 cursor-pointer">
+            Start
+        </button>
+    </div>
+    <div class="my-16 text-8xl font-bold text-transparent" style="background: linear-gradient(to right in oklch, red, orange, yellow, green, blue, blue, violet); background-clip: text">
+        <div id="message">Hello, world!</div>
+    </div>
+</body>
+</html>

--- a/examples/hello-httpkit/src/hello_httpkit.clj
+++ b/examples/hello-httpkit/src/hello_httpkit.clj
@@ -1,0 +1,86 @@
+(ns hello-httpkit
+  (:require
+   [charred.api]
+   [clojure.java.io :as io]
+   [dev.onionpancakes.chassis.compiler :as hc]
+   [dev.onionpancakes.chassis.core :as h]
+   [org.httpkit.server]
+   [reitit.ring.middleware.parameters]
+   [reitit.ring]
+   [ring.util.response]
+   [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
+   [starfederation.datastar.clojure.api :as d*]))
+
+(def read-json (charred.api/parse-json-fn {:async? false :bufsize 1024}))
+
+(defn get-signals [req]
+  (-> req d*/get-signals read-json))
+
+(def home-page
+  (slurp (io/resource "hello-world.html")))
+
+(defn home [_]
+  (-> home-page
+      (ring.util.response/response)
+      (ring.util.response/content-type "text/html")))
+
+(def message "Hello, world!")
+
+(defn ->frag [i]
+  (h/html
+   (hc/compile
+    [:div {:id "message"}
+     (subs message 0 (inc i))])))
+
+(defn hello-world [request]
+  (let [d (-> request get-signals (get "delay") int)]
+    (->sse-response request
+                    {on-open
+                     (fn [sse]
+                       (d*/with-open-sse sse
+                         (dotimes [i (count message)]
+                           (d*/patch-elements! sse (->frag i))
+                           (Thread/sleep d))))})))
+
+(def routes
+  [["/" {:handler home}]
+   ["/hello-world" {:handler hello-world
+                    :middleware [reitit.ring.middleware.parameters/parameters-middleware]}]])
+
+(def router (reitit.ring/router routes))
+
+(def handler (reitit.ring/ring-handler router))
+
+;; ------------------------------------------------------------
+;; Server
+;; ------------------------------------------------------------
+(defonce !server (atom nil))
+
+(defn stop! []
+  (if-let [s @!server]
+    (do (org.httpkit.server/server-stop! s)
+        (reset! !server nil))
+    (throw (ex-info "Server not running" {}))))
+
+(defn start! [handler opts]
+  (when-not (nil? @!server)
+    (stop!))
+  (reset! !server
+          (org.httpkit.server/run-server
+           handler
+           (merge {:port 8080}
+                  opts
+                  {:legacy-return-value? false}))))
+
+(comment
+  (stop!)
+  (start! #'handler {})
+  )
+
+;; ------------------------------------------------------------
+;; Main
+;; ------------------------------------------------------------
+(defn -main [& _]
+  (start! #'handler {:port 8080})
+  (.addShutdownHook (Runtime/getRuntime)
+                    (Thread. #(do (stop!) (shutdown-agents)))))


### PR DESCRIPTION
Based on the Jetty example, I made a starter for http-kit.

I cut some files and indirection — I felt that would help beginners get started.

Caveat: I noticed the `starfederation.datastar.clojure.adapter.http-kit2` namespace, but haven't used it. Not sure what the plans for 1.0 are, maybe it's better get beginners started on http-kit2. I put "draft" on the PR to highlight this.