### PR TITLE
Feature: custom flushing and double flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Release notes for the Clojure SDK
 
 ## 2026-02-13 - RC8
-### Fix
-- Some docs and examples where still using Datastar old syntax. This is now fixed.
+### Fixed
+- Some docs and examples were still using Datastar's old syntax. This is now
+  fixed.
+- Brolti compression now works for the Ring implementation of the SDK by using
+  the new `custom flush` option for write profiles.
 
 ### Added
+- New `custom-flush` option in write profiles allowing to have more control over
+  flushing behavior.
 - A new implementation of the SDK for the Aleph ring adapter has been added.
 
 ### Changed
 - The tests have been refactored in order to be somewhat more legible and REPL friendly.
 
 ## 2025-12-26 - RC7
-### Fix
+### Fixed
 - The clj-kondo config from the sdk library is now properly added into the jar.
 
 ## 2025-12-22 - RC6

--- a/libraries/sdk-brotli/README.md
+++ b/libraries/sdk-brotli/README.md
@@ -12,8 +12,6 @@ This library contains some utilities to work with Brotli.
 Credits to [Anders](https://andersmurphy.com/) and his work on [Hyperlith](https://github.com/andersmurphy/hyperlith)
 from which this library takes it's code.
 
-> [!IMPORTANT]
-> At this moment only Http-kit is supported.
 
 ## Overview
 

--- a/libraries/sdk-brotli/src/main/starfederation/datastar/clojure/brotli.clj
+++ b/libraries/sdk-brotli/src/main/starfederation/datastar/clojure/brotli.clj
@@ -112,7 +112,8 @@
          (->brotli-os opts)
          ac/->os-writer))
    ac/write! (ac/->write-with-temp-buffer!)
-   ac/content-encoding brotli-content-encoding})
+   ac/content-encoding brotli-content-encoding
+   ac/custom-flush ac/double-flush})
 
 
 (defn ->brotli-buffered-writer-profile
@@ -131,6 +132,5 @@
          ac/->os-writer
          ac/->buffered-writer))
    ac/write! ac/write-to-buffered-writer!
-   ac/content-encoding brotli-content-encoding})
-
-
+   ac/content-encoding brotli-content-encoding
+   ac/custom-flush ac/double-flush})

--- a/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -12,16 +12,20 @@
 (def default-write-profile ac/basic-profile)
 
 
-(defn ->send [os opts]
+(defn ->send [raw-os opts]
   (let [{wrap ac/wrap-output-stream
-         write! ac/write!} (ac/write-profile opts default-write-profile)
-        writer (wrap os)]
+         write! ac/write!
+         custom-flush ac/custom-flush} (ac/write-profile opts default-write-profile)
+        wrapped-os (wrap raw-os)
+        flush (if custom-flush
+                custom-flush
+                ac/simple-flush)]
     (fn
       ([]
-       (.close ^Closeable writer))
+       (.close ^Closeable wrapped-os))
      ([event-type data-lines event-opts]
-      (write! writer event-type data-lines event-opts)
-      (ac/flush writer)))))
+      (write! wrapped-os event-type data-lines event-opts)
+      (flush wrapped-os raw-os)))))
 
 
 ;; Note that the send! field has 2 usages:

--- a/src/dev/examples/animation_gzip.clj
+++ b/src/dev/examples/animation_gzip.clj
@@ -52,7 +52,8 @@
                                  {hk-gen/write-profile (brotli/->brotli-profile)}))
 
 (def handler-ring (->handler ring-gen/->sse-response
-                             {ring-gen/write-profile ring-gen/gzip-profile}))
+                             ;{ring-gen/write-profile ring-gen/gzip-profile}
+                             {ring-gen/write-profile (brotli/->brotli-buffered-writer-profile)}))
 
 
 (def handler-aleph (->handler aleph/->sse-response


### PR DESCRIPTION
This PR comes from studying the hirundo source code and conversing with its maintainer. Specifically the way hirundo handles output streams when using brotli.

It turns out that when using brotli, in the case of the SDK's ring implementation, flushing just the brotli output stream does not necessarily mean flushing the output stream it wraps. We need to flush both.

I added the option to pass a custom flushing function to write profiles. This function takes both the wrapped output stream and the raw output stream and can flush only one or both. A `simple-flush` and `double-flush` functions have been added to the common SDK tool box for use in our adapter implementations as in our write profiles.

Using this we now have brotli compression working for Ring (tested with ring-jetty-adapter). 

Cheers,