### PR TITLE
Fix: aleph-malli-schemas namespace typo (stardederation -> starfederation)

### DIFF
--- a/libraries/sdk-aleph-malli-schemas/src/main/starfederation/datastar/clojure/adapter/aleph_schemas.clj
+++ b/libraries/sdk-aleph-malli-schemas/src/main/starfederation/datastar/clojure/adapter/aleph_schemas.clj
@@ -1,4 +1,4 @@
-(ns stardederation.datastar.clojure.adapter.aleph-schemas
+(ns starfederation.datastar.clojure.adapter.aleph-schemas
   (:require
     [malli.core :as m]
     [malli.util :as mu]


### PR DESCRIPTION
## Summary

The `sdk-aleph-malli-schemas` library ships with both its source path and its `(ns …)` form misspelled as `stardederation` instead of `starfederation`:

- `libraries/sdk-aleph-malli-schemas/src/main/stardederation/datastar/clojure/adapter/aleph_schemas.clj`
- `(ns stardederation.datastar.clojure.adapter.aleph-schemas …)`

Consumers requiring the documented namespace `starfederation.datastar.clojure.adapter.aleph-schemas` get a `FileNotFoundException`, so the library is effectively dead-on-arrival.

This PR renames the directory and the `(ns …)` form to the correct spelling. No content changes besides the rename.

## Test plan

- [ ] `bb test:all` still passes (the file isn't referenced by tests, but verifying nothing else regresses)
- [ ] `bb install:all` produces a jar containing `starfederation/datastar/clojure/adapter/aleph_schemas.clj`
- [ ] `(require 'starfederation.datastar.clojure.adapter.aleph-schemas)` works from a downstream project