### PR TITLE
Fix: ring-malli-schemas inter-dep wiring in build tasks

### DIFF
--- a/src/bb/tasks/build.clj
+++ b/src/bb/tasks/build.clj
@@ -72,7 +72,7 @@
    sdk-adapter-ring-malli-schemas-dir
    ['dev.data-star.clojure/sdk
     'dev.data-star.clojure/malli-schemas
-    'dev.data-star.clojure/http-kit]
+    'dev.data-star.clojure/ring]
 
    sdk-malli-schemas-dir
    ['dev.data-star.clojure/sdk]})


### PR DESCRIPTION
## Summary

In \`src/bb/tasks/build.clj\`, the \`lib-dir->deps\` table maps each library directory to the set of \`dev.data-star.clojure/*\` libs whose versions should be updated when version-bumping. The entry for \`sdk-adapter-ring-malli-schemas-dir\` lists \`dev.data-star.clojure/http-kit\` (copy-paste from the http-kit-malli-schemas entry) instead of \`dev.data-star.clojure/ring\`.

\`bb bump-version\` / \`bb set-version\` use this table via \`update-deps-version\` to rewrite the relevant lines in each \`deps.edn\`. With every lib currently in lockstep at the same RC version the bug is masked, but the first non-lockstep release would silently bump the wrong dep in \`sdk-ring-malli-schemas/deps.edn\` (and leave the \`ring\` dep stale).

## Test plan

- [ ] Run \`bb set-version <some-version>\` locally and confirm \`libraries/sdk-ring-malli-schemas/deps.edn\` has its \`dev.data-star.clojure/ring\` entry updated (and no \`http-kit\` reference appears).