### PR TITLE
Fix: add element-namespace to patch-element-options-schemas

### DIFF
--- a/libraries/sdk-malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
+++ b/libraries/sdk-malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
@@ -49,6 +49,13 @@
   (m/validate patch-modes-schema "toto"))
 
 
+(def element-namespaces-schema
+  [:enum
+   consts/element-namespace-html
+   consts/element-namespace-svg
+   consts/element-namespace-mathml])
+
+
 (def patch-element-options-schemas
   (mu/merge
     sse-options-schema
@@ -56,7 +63,8 @@
       [:map
        [common/selector :string]
        [common/patch-mode patch-modes-schema]
-       [common/use-view-transition :boolean]])))
+       [common/use-view-transition :boolean]
+       [common/element-namespace element-namespaces-schema]])))
 
 ;; -----------------------------------------------------------------------------
 (def selector-schema :string)


### PR DESCRIPTION
## Summary

The `:d*.elements/namespace` option was added to `patch-elements!` / `patch-elements-seq!` in RC6, but the malli schema for those functions' options map (`patch-element-options-schemas` in `libraries/sdk-malli-schemas/.../api/common_schemas.clj`) was never updated.

Callers passing `d*/element-ns d*/ns-svg` through malli-instrumented code currently fail with `:malli.core/invalid-input` even though the SDK happily accepts the option (and tests cover it).

This PR adds an `element-namespaces-schema` enum that mirrors the html/svg/mathml constants from `consts` and includes it as an optional key on `patch-element-options-schemas`. By transitivity the http-kit / aleph / ring `->sse-response` schemas also pick it up via the existing schema chain.

## Test plan

- [ ] `bb test:all` still passes
- [ ] Add an explicit assertion (or eyeball it in the REPL) that, with `mi/instrument!`, `(d*/patch-elements! sse-gen "<svg/>" {d*/element-ns d*/ns-svg})` no longer throws.