### PR TITLE
Chore: docstring refresh and typo sweep

### DIFF
--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -29,7 +29,7 @@
   Specific SSE headers are set automatically, the user provided ones will be
   merged.
 
-  Note that the SSE connection stays opened util you close it.
+  Note that the SSE connection stays opened until you close it.
 
   General options:
   - `:status`: status for the HTTP response, defaults to 200.

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
@@ -23,7 +23,7 @@
 (defn- as-channel
   "
   Replacement for [[hk-server/as-channel]] that doesn't deal with websockets
-  and doen't call `on-open` itself.
+  and doesn't call `on-open` itself.
 
   `on-open` is meant to be called by either a middleware or an interceptor on the return.
   "
@@ -44,7 +44,7 @@
   You need to use either [[start-responding-middleware]] or
   [[start-responding-interceptor]].
 
-  Note that the SSE connection stays opened util you close it.
+  Note that the SSE connection stays opened until you close it.
 
   Specific SSE headers are set automatically, the user provided ones will be
   merged.

--- a/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -34,7 +34,7 @@
   provided as argument of the different callbacks described below.
 
   In sync mode, the connection is closed automatically when the handler is
-  done running. You need to explicitly close it in rinc async.
+  done running. You need to explicitly close it in ring async.
 
   Opts:
   - `:status`: status for the HTTP response, defaults to 200

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -55,7 +55,7 @@ Some scripts are provided:
 ;; -----------------------------------------------------------------------------
 (def CDN-url
   "URL for the Datastar js bundle tracking the latest Datastar, currently
-  v1.0.0-RC7."
+  v1.0.1."
 
   "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js")
 
@@ -69,7 +69,7 @@ Some scripts are provided:
 ;; -----------------------------------------------------------------------------
 (defmacro lock-sse!
   "Hold onto the lock of a `sse-gen` while executing `body`. This allows for
-  preventing concurent sending of sse events. Sse generators use
+  preventing concurrent sending of sse events. Sse generators use
   [[java.util.concurrent.locks.ReentrantLock]] under the hood.
 
   Ex:
@@ -102,9 +102,9 @@ Some scripts are provided:
 
 
 (defmacro with-open-sse
-  "Macro functioning similarly to [[clojure.core/with-open]]. It evalutes the
+  "Macro functioning similarly to [[clojure.core/with-open]]. It evaluates the
   `body` inside a try expression and closes the `sse-gen` at the end using
-  [[close-see!]] in a finally clause.
+  [[close-sse!]] in a finally clause.
 
   Ex:
   ```
@@ -199,7 +199,7 @@ Some scripts are provided:
 
   Whether to patch the signal only if it does not already
   exist. If not provided, the Datastar client side will default to false, which
-  will cause the data to be patchd into the signals."
+  will cause the data to be patched into the signals."
   common/only-if-missing)
 
 ;; Script opts
@@ -266,7 +266,7 @@ Some scripts are provided:
   consts/element-namespace-mathml)
 
 (defn patch-elements!
-  "Send HTML elements to the browser to be patchd into the DOM.
+  "Send HTML elements to the browser to be patched into the DOM.
 
   Args:
   - `sse-gen`: the sse generator to send from
@@ -361,7 +361,7 @@ Some scripts are provided:
   This function returns either a string or an InputStream depending on the
   HTTP method of the request.
 
-  - In the case of a GET request a string is returned (the signals are found in
+  - For GET and DELETE requests a string is returned (the signals are found in
     the `:query-params` map of the request)
   - For all other HTTP methods an `InputStream` is returned (the signals are the
     `:body` of the request)

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api/scripts.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api/scripts.clj
@@ -51,7 +51,7 @@
 
 (comment
   (= (->script-tag "console.log('hello')" {})
-     "<script data-init=\"el.remove()\">console.log('hello')</script>")
+     "<script data-effect=\"el.remove()\">console.log('hello')</script>")
 
   (= (->script-tag "console.log('hello')"
                     {common/auto-remove false})
@@ -67,6 +67,6 @@
   (= (->script-tag "console.log('hello');\nconsole.log('world!!!')"
                   {common/auto-remove :true
                    common/attributes {:type "module" :data-something 1}})
-     "<script type=\"module\" data-something=\"1\" data-init=\"el.remove()\">console.log('hello');\nconsole.log('world!!!')</script>"))
+     "<script type=\"module\" data-something=\"1\" data-effect=\"el.remove()\">console.log('hello');\nconsole.log('world!!!')</script>"))
 
 

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api/signals.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api/signals.clj
@@ -45,9 +45,14 @@
 ;; Read signals
 ;; -----------------------------------------------------------------------------
 (defn get-signals
-  "Returns the signals json string. You need to use some middleware
-  that adds the :query-params key to the request for this function
-  to work properly.
+  "Extract datastar signals from a ring request map.
+
+  - For GET and DELETE requests, returns the signals json string from
+    `[:query-params consts/datastar-key]`. You need to use some middleware
+    that adds the `:query-params` key to the request for this function to
+    work properly.
+  - For all other HTTP methods, returns the request `:body` as an
+    `InputStream`.
 
   (Bring your own json parsing)"
   [request]

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api/sse.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api/sse.clj
@@ -36,7 +36,7 @@
   - `:headers`: custom headers for the response
  
   The SSE headers this function provides can be overriden by the optional ones.
-  Be carreful with the following headers:
+  Be careful with the following headers:
 
   - \"Cache-Control\"
   - \"Content-Type\"

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/protocols.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/protocols.clj
@@ -5,7 +5,7 @@
   (send-event! [this event-type data-lines opts] "Send sse event.")
   (get-lock [this] "Access to the lock used in the generator.")
   (close-sse! [this] "Close connection.")
-  (sse-gen? [this] "Test wheter a value is a SSEGenerator."))
+  (sse-gen? [this] "Test whether a value is a SSEGenerator."))
 
 
 (defn throw-not-implemented [type method]


### PR DESCRIPTION
## Summary

Documentation-only changes. No behavior changes, no API changes.

**Stale content fixed**

- \`api/CDN-url\`: docstring still claimed "currently v1.0.0-RC7" while the URL points to v1.0.1.
- \`api/get-signals\` (and \`api.signals/get-signals\`): docstrings said GET returns a string and "all other HTTP methods" return an InputStream. RC9 added DELETE to the GET branch (#23), so the docs are updated to match the code: \`(:get :delete) -> string\`, otherwise InputStream.
- \`api.scripts/->script-tag\` comment block: examples showed \`data-init=\"el.remove()\"\` but the code emits \`data-effect=...\` and the SDK tests assert on \`data-effect\`. Comment is now in sync with code.

**Typo sweep**

- \`wheter\` -> \`whether\` (\`protocols.clj\`)
- \`carreful\` -> \`careful\` (\`api/sse.clj\`)
- \`concurent\` -> \`concurrent\` (\`api.clj\`)
- \`evalutes\` -> \`evaluates\` (\`api.clj\`)
- \`[[close-see!]]\` -> \`[[close-sse!]]\` (\`api.clj\`)
- \`patchd\` -> \`patched\` (\`api.clj\`, two occurrences)
- \`rinc async\` -> \`ring async\` (\`adapter/ring.clj\`)
- \`util you close it\` -> \`until you close it\` (\`adapter/http-kit.clj\`, \`adapter/http-kit2.clj\`)
- \`doen't\` -> \`doesn't\` (\`adapter/http-kit2.clj\`)

## Test plan

- [ ] No code paths touched; existing tests should still pass without changes.
- [ ] Spot-check the cljdoc rendering once published (\`with-open-sse\` cross-link especially).