### PR TITLE
CI: upload aleph and aleph-malli-schemas jar artifacts

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -77,6 +77,20 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v4.6.2
         with:
+          name: adapter-aleph.jar
+          path: libraries/sdk-aleph/target/*.jar
+          if-no-files-found: error
+          compression-level: 0
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v4.6.2
+        with:
+          name: adapter-aleph-malli-schemas.jar
+          path: libraries/sdk-aleph-malli-schemas/target/*.jar
+          if-no-files-found: error
+          compression-level: 0
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v4.6.2
+        with:
           name: adapter-http-kit.jar
           path: libraries/sdk-http-kit/target/*.jar
           if-no-files-found: error


### PR DESCRIPTION
## Summary

The release workflow currently uploads jar artifacts for **7** of the **9** published libraries: sdk, brotli, http-kit, http-kit-malli-schemas, malli-schemas, ring, ring-malli-schemas. The aleph and aleph-malli-schemas libraries (added in RC8 and RC9) are missing.

\`bb publish:all\` does push them to Clojars because they live in \`sdk-lib-dirs\`, so manual releases continue to work — but the CI artifact set is asymmetric and easy to misread as "those libs are not released". This PR adds the two missing \`actions/upload-artifact\` steps next to the http-kit ones to bring CI in line with the published surface.

## Test plan

- [ ] Workflow run after merge produces \`adapter-aleph.jar\` and \`adapter-aleph-malli-schemas.jar\` artifacts alongside the existing seven.