### PR TITLE
Refactor: have adapter.common/close-sse! throw on exceptions

### DIFF
--- a/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph/impl.clj
+++ b/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph/impl.clj
@@ -86,17 +86,15 @@
   (close-sse! [this]
     (u/lock! lock
       (if on-close
-        (let [closing-res (ac/close-sse! #(do (send!))
-                                         #(when on-close (on-close this)))]
-
-          ;; on-close serves as a sentinel, that way when
-          ;; the user close the SSEGenerator is closed (as opposed to the browser)
-          ;; we don't close again when the manifold stream on-closed callback is called
-          (set! on-close nil)
-          (s/close! stream)
-          (if (instance? Exception closing-res)
-            (throw closing-res)
-            closing-res))
+        (try
+          (ac/close-sse! #(do (send!))
+                         #(when on-close (on-close this)))
+          (finally
+            ;; on-close serves as a sentinel, that way when
+            ;; the user closes the SSEGenerator (as opposed to the browser)
+            ;; we don't close again when the manifold stream on-closed callback is called
+            (set! on-close nil)
+            (s/close! stream)))
         false)))
 
   (sse-gen? [_] true)

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -69,11 +69,7 @@
 
        :on-close
        (fn [_ status]
-         (let [closing-res
-               (ac/close-sse!
-                #(when-let [send! (deref future-send! 0 nil)] (send!))
-                #(when on-close-cb
-                   (on-close-cb (deref future-gen 0 nil) status)))]
-           (if (instance? Exception closing-res)
-             (throw closing-res)
-             closing-res)))})))
+         (ac/close-sse!
+          #(when-let [send! (deref future-send! 0 nil)] (send!))
+          #(when on-close-cb
+             (on-close-cb (deref future-gen 0 nil) status))))})))

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
@@ -87,14 +87,10 @@
 
          :on-close
          (fn [_ status]
-           (let [closing-res
-                 (ac/close-sse!
-                  #(when-let [send! (deref future-send! 0 nil)] (send!))
-                  #(when on-close-cb
-                     (on-close-cb (deref future-gen 0 nil) status)))]
-             (if (instance? Exception closing-res)
-               (throw closing-res)
-               closing-res)))})
+           (ac/close-sse!
+            #(when-let [send! (deref future-send! 0 nil)] (send!))
+            #(when on-close-cb
+               (on-close-cb (deref future-gen 0 nil) status))))})
       :status (or status 200)
       :headers (ac/headers ring-request opts)
       ::datastar-sse-response true)))

--- a/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -77,14 +77,13 @@
     (u/lock! lock
       ;; If either send! or on-close are here we try to close them
       (if (or send! on-close)
-        (let [res (ac/close-sse! #(when send! (send!))
-                                 #(when on-close (on-close this)))]
-          ;; We make sure to clean them up after closing
-          (set! send! nil)
-          (set! on-close nil)
-          (if (instance? Exception res)
-            (throw res)
-            true))
+        (try
+          (ac/close-sse! #(when send! (send!))
+                         #(when on-close (on-close this)))
+          (finally
+            ;; Clean up regardless of whether closing threw
+            (set! send! nil)
+            (set! on-close nil)))
         false)))
 
   (sse-gen? [_] true)

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -338,10 +338,11 @@
 
   Both thunks are called using [[try-closing]] to capture exceptions.
 
-  This function rethrows the first `java.lang.Throwable` encountered. Otherwise
-  it returns either `true` when all thunks are exceptions free or an
-  exception created with [[ex-info]] that contains the thunks exceptions in it's
-  data under the key [[closing-exceptions]]."
+  Returns `true` when both thunks complete without exceptions. If a thunk
+  threw a `java.lang.Throwable` that wasn't caught, that throwable
+  propagates. Otherwise, if one or more thunks threw an exception, this
+  function throws an [[ex-info]] whose data contains the thunks'
+  exceptions under the key [[closing-exceptions]]."
   [close-io! on-close!]
   (let [results [(try-closing close-io! "Error closing the output stream.")
                  (try-closing on-close! "Error calling the on close callback.")]
@@ -350,8 +351,8 @@
         throwable (some identity throwables)]
     (cond
       throwable        (throw throwable)
-      (seq exceptions) (ex-info "Error closing the sse-gen."
-                                {closing-exceptions exceptions})
+      (seq exceptions) (throw (ex-info "Error closing the sse-gen."
+                                       {closing-exceptions exceptions}))
       :else            true)))
 
 


### PR DESCRIPTION
## Summary

\`adapter.common/close-sse!\` had an inconsistent contract: it rethrew \`Throwable\`s caught while closing, but for plain \`Exception\`s it *returned* the ex-info to the caller. Every adapter (ring, http-kit, http-kit2, aleph) repeated the same shim to convert the returned value back into a throw:

\`\`\`clojure
(let [res (ac/close-sse! …)]
  (if (instance? Exception res)
    (throw res)
    res))
\`\`\`

This PR makes \`close-sse!\` throw the ex-info itself and removes the shim from each adapter.

The two adapters that mutate state after closing (\`ring\`, \`aleph\`) now wrap the call in \`try/finally\` so the cleanup runs whether closing throws or returns. This also makes them resilient to \`Throwable\`s — previously, an \`Error\` from \`close-sse!\` would skip the field cleanup.

## Behavior changes

- \`close-sse!\` returns \`true\` on success — unchanged.
- \`close-sse!\` now **throws** the ex-info instead of returning it on closing failure.
- Adapters now finalize their internal state (clearing \`send!\`, \`on-close\`, closing the manifold stream) on every close attempt, not just successful ones.

If anyone has been pattern-matching on the return value of \`adapter.common/close-sse!\` to detect failures, they'll need to switch to a \`try / catch ExceptionInfo\` and check for \`closing-exceptions\` in \`ex-data\`. (\`get-closing-exceptions\` already exists for this.)

## Test plan

- [ ] \`bb test:all\` passes
- [ ] In a REPL, force a close failure (e.g. \`->sse-response\` with an \`on-close\` callback that throws) and confirm the exception now propagates up and that \`ex-data\` carries \`:d*.sse/closing-exceptions\`.
- [ ] Confirm in the ring and aleph implementations that \`send!\` / \`on-close\` are nilled out and the manifold stream is closed even when the close path throws.