### PR TITLE
Docs: warn about JS-string interpolation in script helpers

### DIFF
--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -469,6 +469,13 @@ Some scripts are provided:
   "Log msg in the browser console.
 
   Same behavior as [[execute-script!]].
+
+  > [!WARNING]
+  > `msg` is interpolated verbatim into a JavaScript double-quoted string
+  > literal. The caller is responsible for ensuring `msg` is safe to embed
+  > there (no unescaped `\"`, `\\`, `</script>`, newlines, or other
+  > characters that would break out of the literal). Never pass
+  > unsanitized user input directly.
   "
   ([sse-gen msg]
    (console-log! sse-gen msg {}))
@@ -480,6 +487,13 @@ Some scripts are provided:
   "Log error msg in the browser console.
 
   Same behavior as [[execute-script!]].
+
+  > [!WARNING]
+  > `msg` is interpolated verbatim into a JavaScript double-quoted string
+  > literal. The caller is responsible for ensuring `msg` is safe to embed
+  > there (no unescaped `\"`, `\\`, `</script>`, newlines, or other
+  > characters that would break out of the literal). Never pass
+  > unsanitized user input directly.
   "
   ([sse-gen msg]
    (console-error! sse-gen msg {}))
@@ -491,6 +505,13 @@ Some scripts are provided:
   "Redirect a page using a script.
 
   Same behavior as [[execute-script!]].
+
+  > [!WARNING]
+  > `url` is interpolated verbatim into a JavaScript double-quoted string
+  > literal. The caller is responsible for ensuring `url` is safe to embed
+  > there (no unescaped `\"`, `\\`, `</script>`, newlines, or other
+  > characters that would break out of the literal). Never pass
+  > unsanitized user input directly.
   "
   ([sse-gen url]
    (redirect! sse-gen url {}))


### PR DESCRIPTION
## Summary

\`console-log!\`, \`console-error!\`, and \`redirect!\` build a JavaScript expression by concatenating their argument verbatim into a double-quoted string literal:

\`\`\`clojure
(execute-script! sse-gen (str \"console.log(\\\"\" msg \"\\\")\") opts)
(execute-script! sse-gen (str \"setTimeout(() => window.location.href =\\\"\" url \"\\\")\") opts)
\`\`\`

A caller that passes unsanitized user input ends up with a script-injection vector — an embedded \`\"\` breaks out of the literal, an embedded \`</script>\` breaks out of the wrapping \`<script>\` tag.

In practice these helpers are typically called with constants or server-derived values, so this is a contract issue rather than an immediate bug. The contract just isn't documented anywhere.

This PR adds a WARNING admonition to each of the three docstrings spelling out the requirement: the caller is responsible for ensuring the input is JS-string-safe (no unescaped \`\"\`, \`\\\\\`, \`</script>\`, newlines).

I deliberately stopped short of adding actual escaping inside the helpers — that would change behavior in a way callers may already work around, and I figured the docs change should land first. Happy to follow up with an opt-in escaping helper if that direction is preferred.

## Test plan

- [ ] No code paths touched; existing tests should still pass.
- [ ] Eyeball the cljdoc rendering once published to confirm the WARNING block renders.