### PR TITLE
Add opt-in sanitizers and docstring warnings for user-controlled input

### DIFF
--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -284,6 +284,15 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
+
+  > [!WARNING]
+  > [[id]], [[selector]], [[patch-mode]] and [[element-ns]] are written
+  > verbatim onto a single line of the SSE wire format. A newline (`\\n`
+  > or `\\r`) in any of these values lets a caller inject arbitrary SSE
+  > lines (and forge whole events) into the stream. Treat these as
+  > developer-controlled; if any of them must come from user input, run
+  > the value through [[assert-sse-line-safe!]] (or your own validator)
+  > before passing it in.
   "
   ([sse-gen elements]
    (patch-elements! sse-gen elements {}))
@@ -292,7 +301,9 @@ Some scripts are provided:
 
 
 (defn patch-elements-seq!
-  "Same as [[patch-elements!]] except that it takes a seq of elements."
+  "Same as [[patch-elements!]] except that it takes a seq of elements.
+
+  See [[patch-elements!]]'s warning about option-line injection."
   ([sse-gen elements]
    (patch-elements-seq! sse-gen elements {}))
   ([sse-gen elements opts]
@@ -319,6 +330,11 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
+
+  > [!WARNING]
+  > `selector` and [[id]] are written verbatim onto a single line of the
+  > SSE wire format. See [[patch-elements!]]'s warning, and use
+  > [[assert-sse-line-safe!]] if either value can come from user input.
   "
   ([sse-gen selector]
    (remove-element! sse-gen selector {}))
@@ -348,6 +364,11 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
+
+  > [!WARNING]
+  > [[id]] is written verbatim onto a single line of the SSE wire format.
+  > A newline in it allows SSE event injection. If the value can come
+  > from user input, sanitize it with [[assert-sse-line-safe!]] first.
   "
   ([sse-gen signals-content]
    (patch-signals! sse-gen signals-content {}))
@@ -396,6 +417,18 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
+
+  > [!WARNING]
+  > `script-text` is interpolated as raw HTML inside the `<script>` tag,
+  > and each value in [[attributes]] is interpolated raw inside a
+  > double-quoted attribute. Both are treated as developer-controlled.
+  > If user input must reach either, sanitize it first:
+  > - call [[assert-script-body-safe!]] on `script-text` to reject
+  >   `</script>` (which would close the tag prematurely);
+  > - call [[escape-script-attribute-value]] on attribute values to
+  >   defuse `\"`, `&`, `<`, `>`;
+  > - call [[assert-script-attribute-name-safe!]] on attribute names you
+  >   don't fully control.
   "
   ([sse-gen script-text]
    (scripts/execute-script! sse-gen script-text {}))
@@ -519,6 +552,83 @@ Some scripts are provided:
    (execute-script! sse-gen
                     (str "setTimeout(() => window.location.href =\"" url "\")")
                     opts)))
+
+
+;; -----------------------------------------------------------------------------
+;; Sanitizers
+;; -----------------------------------------------------------------------------
+;; These are opt-in helpers. The patch / signal / script functions trust
+;; their inputs by design — values are expected to come from the developer,
+;; not from user input. When that assumption doesn't hold (e.g. a session
+;; id propagated into [[id]], a user-chosen CSS path in [[selector]],
+;; arbitrary data interpolated into a script tag), run the relevant value
+;; through the matching helper below first.
+(defn assert-sse-line-safe!
+  "Throw an [[clojure.core/ex-info]] if `(str v)` contains `\\n` or `\\r`,
+  otherwise return `(str v)`.
+
+  Use this on values that will reach an SSE option line — [[id]],
+  [[selector]], [[patch-mode]], [[element-ns]] and friends — when those
+  values can come from user input. A newline in any of those would let
+  the caller append arbitrary SSE lines to the stream and forge events.
+
+  `name` is the field name and is included in the thrown error for
+  context (e.g. `\"selector\"`).
+
+  Ex:
+  ```clojure
+  (patch-elements! sse-gen html
+    {d*/selector (d*/assert-sse-line-safe! user-selector \"selector\")})
+  ```"
+  [v name]
+  (u/assert-no-newline! v name))
+
+
+(defn assert-script-body-safe!
+  "Throw if `script-text` contains `</script` (case-insensitive); otherwise
+  return `script-text`.
+
+  HTML5 raw-text element parsing closes a `<script>` element as soon as it
+  sees `</script`, regardless of the trailing characters. Escaping the
+  occurrence would change the JS that runs, so the only safe option is to
+  reject it.
+
+  Use this on `script-text` you build from untrusted input before passing
+  to [[execute-script!]]."
+  [script-text]
+  (when (and (string? script-text)
+             (re-find #"(?i)</script" script-text))
+    (throw (ex-info "Script content must not contain '</script' (would close the tag)."
+                    {:script script-text})))
+  script-text)
+
+
+(defn escape-script-attribute-value
+  "Return `v` (coerced to a string) with the four HTML attribute-context
+  characters escaped: `&`, `\"`, `<`, `>`. Use it on values you put into
+  the [[attributes]] map of [[execute-script!]] when those values come
+  from untrusted input — without escaping, a value containing `\"` can
+  break out of the attribute and inject extra attributes."
+  [v]
+  (-> (str v)
+      (.replace "&" "&amp;")
+      (.replace "\"" "&quot;")
+      (.replace "<" "&lt;")
+      (.replace ">" "&gt;")))
+
+
+(def ^:private valid-attr-name-re #"[A-Za-z_][A-Za-z0-9_:.-]*")
+
+(defn assert-script-attribute-name-safe!
+  "Throw if `(name k)` doesn't match `[A-Za-z_][A-Za-z0-9_:.-]*`; otherwise
+  return `(name k)`. HTML attribute names from untrusted input should be
+  validated before being interpolated into a `<script>` tag opener."
+  [k]
+  (let [n (name k)]
+    (when-not (re-matches valid-attr-name-re n)
+      (throw (ex-info (str "Invalid script attribute name: " (pr-str n))
+                      {:attribute n})))
+    n))
 
 
 ;; -----------------------------------------------------------------------------

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/utils.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/utils.clj
@@ -57,6 +57,21 @@
   (not (string/blank? s)))
 
 
+(defn assert-no-newline!
+  "Throw an [[ex-info]] if `(str v)` contains `\\n` or `\\r`.
+
+  Used to defend against SSE event injection: option/id values are written
+  to a single line of the SSE wire format, so a newline in user-controlled
+  input would let an attacker append arbitrary lines (and forge whole
+  events). `name` is included in the error for context. Returns `(str v)`."
+  [v ^String name]
+  (let [s (str v)]
+    (when (or (.contains s "\n") (.contains s "\r"))
+      (throw (ex-info (str name " must not contain newlines or carriage returns.")
+                      {:value v :name name})))
+    s))
+
+
 (defn merge-transient!
   "Merge a map `m` into a transient map `tm`.
   Returns the transient map without calling [[persistent!]] on it."

--- a/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
+++ b/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
@@ -354,3 +354,76 @@
 
 (comment
   (ltr/run-test-var #'test-execute-script!))
+
+
+;; -----------------------------------------------------------------------------
+;; Sanitizer helpers
+;; -----------------------------------------------------------------------------
+;; The patch / signal / script functions trust their inputs by design. These
+;; opt-in helpers let callers defend a value at the boundary when it can
+;; carry user input.
+(defn- threw? [thunk]
+  (try (thunk) false (catch Exception _ true)))
+
+(defdescribe test-assert-sse-line-safe!
+  (describe d*/assert-sse-line-safe!
+    (specify "passes through clean values"
+      (expect (= "1" (d*/assert-sse-line-safe! "1" "id")))
+      (expect (= "#main" (d*/assert-sse-line-safe! "#main" "selector")))
+      (expect (= "" (d*/assert-sse-line-safe! "" "id"))))
+    (specify "coerces to string"
+      (expect (= "42" (d*/assert-sse-line-safe! 42 "id"))))
+    (specify "throws on \\n"
+      (expect (threw? #(d*/assert-sse-line-safe! "1\nevent: bad" "id"))))
+    (specify "throws on \\r"
+      (expect (threw? #(d*/assert-sse-line-safe! "1\rmalicious" "id"))))
+    (specify "throws on \\r\\n"
+      (expect (threw? #(d*/assert-sse-line-safe! "x\r\ny" "selector"))))))
+
+
+(defdescribe test-assert-script-body-safe!
+  (describe d*/assert-script-body-safe!
+    (specify "passes through clean script bodies"
+      (expect (= "alert(1)" (d*/assert-script-body-safe! "alert(1)")))
+      (expect (= "" (d*/assert-script-body-safe! ""))))
+    (specify "lenient on non-string (consistent with execute-script! type expectations)"
+      (expect (= :test (d*/assert-script-body-safe! :test))))
+    (specify "throws on </script (lowercase)"
+      (expect (threw? #(d*/assert-script-body-safe! "</script>"))))
+    (specify "throws on </SCRIPT (any case)"
+      (expect (threw? #(d*/assert-script-body-safe! "x; </ScRiPt foo"))))))
+
+
+(defdescribe test-escape-script-attribute-value
+  (describe d*/escape-script-attribute-value
+    (specify "passes through clean values"
+      (expect (= "module" (d*/escape-script-attribute-value "module")))
+      (expect (= "" (d*/escape-script-attribute-value ""))))
+    (specify "coerces to string"
+      (expect (= "1" (d*/escape-script-attribute-value 1))))
+    (specify "escapes the four HTML attribute-context characters"
+      (expect (= "a&quot;b" (d*/escape-script-attribute-value "a\"b")))
+      (expect (= "&amp;" (d*/escape-script-attribute-value "&")))
+      (expect (= "&lt;a&gt;" (d*/escape-script-attribute-value "<a>"))))
+    (specify "escapes & before quotes (no double-escape)"
+      (expect (= "&amp;quot;" (d*/escape-script-attribute-value "&quot;"))))))
+
+
+(defdescribe test-assert-script-attribute-name-safe!
+  (describe d*/assert-script-attribute-name-safe!
+    (specify "accepts valid names"
+      (expect (= "type" (d*/assert-script-attribute-name-safe! "type")))
+      (expect (= "data-x" (d*/assert-script-attribute-name-safe! :data-x)))
+      (expect (= "x:y" (d*/assert-script-attribute-name-safe! "x:y"))))
+    (specify "throws on names with whitespace or =\""
+      (expect (threw? #(d*/assert-script-attribute-name-safe! "x onclick=foo")))
+      (expect (threw? #(d*/assert-script-attribute-name-safe! "x\"y"))))
+    (specify "throws on empty"
+      (expect (threw? #(d*/assert-script-attribute-name-safe! ""))))))
+
+
+(comment
+  (ltr/run-test-var #'test-assert-sse-line-safe!)
+  (ltr/run-test-var #'test-assert-script-body-safe!)
+  (ltr/run-test-var #'test-escape-script-attribute-value)
+  (ltr/run-test-var #'test-assert-script-attribute-name-safe!))


### PR DESCRIPTION
Reworked per @JeremS's feedback. The original PR enforced newline/escape sanitization inside the hot path; this version is purely **opt-in** and changes no existing behavior.

Brotli charset has been split out to #35.

## What this PR is now

### Opt-in sanitizers (new public helpers in `starfederation.datastar.clojure.api`)
- `assert-sse-line-safe!` — throw if `(str v)` contains `\n` or `\r`. For [[id]], [[selector]], [[patch-mode]], [[element-ns]] when those values cross a trust boundary.
- `assert-script-body-safe!` — throw if `script-text` contains `</script` (any case). The HTML5 raw-text rule means escaping isn't safe; rejection is the only correct option.
- `escape-script-attribute-value` — return a string with `& \" < >` HTML-escaped, for [[attributes]] values that come from user input.
- `assert-script-attribute-name-safe!` — validate against `[A-Za-z_][A-Za-z0-9_:.-]*`, for attribute names you don't fully control.

All backed by a small `utils/assert-no-newline!` private helper.

### Docstring warnings
`> [!WARNING]` blocks added to `patch-elements!`, `patch-elements-seq!`, `remove-element!`, `patch-signals!`, `execute-script!`, matching the style #31 introduced for `console-log!` / `console-error!` / `redirect!`. They call out which fields go raw onto the wire / into the script tag, and point at the helpers above.

## What this PR is *not*
- No automatic validation in `add-opt-line!`, `rework-options`, or `->script-tag`.
- No behavior change for existing callers.

## Test plan
- [x] `bb test:bb` — 62/62 pass (46 pre-existing + 16 new specs covering the 4 helpers).
- [x] `bb test:all` — non-browser tests pass; the only failures are the pre-existing etaoin/geckodriver smoke tests.
- [x] No diff vs `main` outside `api.clj` (warnings + helpers), `utils.clj` (helper impl), and `api_test.clj` (helper tests).