### PR TITLE
Fix: use UTF-8 explicitly in brotli compress/decompress

### DIFF
--- a/libraries/sdk-brotli/src/main/starfederation/datastar/clojure/brotli.clj
+++ b/libraries/sdk-brotli/src/main/starfederation/datastar/clojure/brotli.clj
@@ -18,7 +18,8 @@
      Encoder$Mode
      BrotliOutputStream]
     [com.aayushatharva.brotli4j.decoder Decoder]
-    [java.io OutputStream]))
+    [java.io OutputStream]
+    java.nio.charset.StandardCharsets))
 
 
 ;; Code taken from https://github.com/andersmurphy/hyperlith
@@ -64,16 +65,16 @@
 
   [data & {:as opts}]
   (-> (if (string? data)
-        (String/.getBytes data)
+        (String/.getBytes data StandardCharsets/UTF_8)
         ^byte/1 data)
       (Encoder/compress (encoder-params opts))))
 
 
 (defn decompress
-  "Decompress Brotli compressed data, returns a string."
+  "Decompress Brotli compressed data, returns a string (decoded as UTF-8)."
   [data]
   (let [decompressed (Decoder/decompress data)]
-    (String/new (.getDecompressedData decompressed))))
+    (String/new (.getDecompressedData decompressed) StandardCharsets/UTF_8)))
 
 
 (comment

--- a/src/test/brotli/starfederation/datastar/clojure/brotli_test.clj
+++ b/src/test/brotli/starfederation/datastar/clojure/brotli_test.clj
@@ -73,7 +73,12 @@
             (ct/append-then-flush writer "some text")
             (ct/append-then-flush writer "some other text"))
           (reset! !res (-> baos .toByteArray (read-bytes {:brotli true})))
-          (expect (= @!res "some textsome other text"))))))
+          (expect (= @!res "some textsome other text")))))
+
+  (describe "compress / decompress charset"
+    (specify "non-ASCII text roundtrips through UTF-8 regardless of platform default"
+      (let [s "héllo — café — Ω 🚀"]
+        (expect (= s (brotli/decompress (brotli/compress s))))))))
 
 
 


### PR DESCRIPTION
Split off from #32 per @JeremS's request — this is the brotli-only piece.

## Summary

`brotli/compress` and `brotli/decompress` had no charset argument on `String/.getBytes` and `String/new`, so they fell back to the JVM platform default. Non-ASCII content silently corrupts on JVMs whose default charset isn't UTF-8 (Windows JDK ≤17, some misconfigured containers).

This PR uses `StandardCharsets/UTF_8` explicitly, matching the rest of the SDK (`adapter/common.clj`'s `->os-writer`) and the convention in [hyperlith](https://github.com/andersmurphy/hyperlith).

## Test plan
- [x] New roundtrip test with non-ASCII content (`"héllo — café — Ω 🚀"`) added to `brotli_test.clj`.
- [x] `bb test:bb` — 46/46 (this lib is JVM-only; bb run is just a smoke check that nothing else broke).
- [x] `bb test:all` non-browser tests pass; the only failures are the pre-existing etaoin/geckodriver smoke tests, unrelated.