### PR TITLE
Proposal: safe-by-default patch/script API with unsafe-* escape hatches

### DIFF
--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -265,6 +265,110 @@ Some scripts are provided:
   "element namespace: mathMl namespace"
   consts/element-namespace-mathml)
 
+;; -----------------------------------------------------------------------------
+;; Sanitizers
+;; -----------------------------------------------------------------------------
+;; The atomic helpers backing the safe-by-default validation. They are
+;; public so callers can also validate at a different boundary (e.g.
+;; before passing a value into one of the `unsafe-*` variants below).
+(defn assert-sse-line-safe!
+  "Throw an [[clojure.core/ex-info]] if `(str v)` contains `\\n` or `\\r`,
+  otherwise return `(str v)`.
+
+  Use this on values that will reach an SSE option line — [[id]],
+  [[selector]], [[patch-mode]], [[element-ns]] and friends — when those
+  values can come from user input. A newline in any of those would let
+  the caller append arbitrary SSE lines to the stream and forge events.
+
+  `name` is the field name and is included in the thrown error for
+  context (e.g. `\"selector\"`)."
+  [v name]
+  (u/assert-no-newline! v name))
+
+
+(defn assert-script-body-safe!
+  "Throw if `script-text` contains `</script` (case-insensitive); otherwise
+  return `script-text`.
+
+  HTML5 raw-text element parsing closes a `<script>` element as soon as
+  it sees `</script`, regardless of the trailing characters. Escaping
+  the occurrence would change the JS that runs, so the only safe option
+  is to reject it."
+  [script-text]
+  (when (and (string? script-text)
+             (re-find #"(?i)</script" script-text))
+    (throw (ex-info "Script content must not contain '</script' (would close the tag)."
+                    {:script script-text})))
+  script-text)
+
+
+(defn escape-script-attribute-value
+  "Return `v` (coerced to a string) with the four HTML attribute-context
+  characters escaped: `&`, `\"`, `<`, `>`. Use it on values you put into
+  the [[attributes]] map of [[execute-script!]] when those values come
+  from untrusted input — without escaping, a value containing `\"` can
+  break out of the attribute and inject extra attributes."
+  [v]
+  (-> (str v)
+      (.replace "&" "&amp;")
+      (.replace "\"" "&quot;")
+      (.replace "<" "&lt;")
+      (.replace ">" "&gt;")))
+
+
+(def ^:private valid-attr-name-re #"[A-Za-z_][A-Za-z0-9_:.-]*")
+
+(defn assert-script-attribute-name-safe!
+  "Throw if `(name k)` doesn't match `[A-Za-z_][A-Za-z0-9_:.-]*`; otherwise
+  return `(name k)`."
+  [k]
+  (let [n (name k)]
+    (when-not (re-matches valid-attr-name-re n)
+      (throw (ex-info (str "Invalid script attribute name: " (pr-str n))
+                      {:attribute n})))
+    n))
+
+
+;; -----------------------------------------------------------------------------
+;; Patch elements / signals / scripts
+;; -----------------------------------------------------------------------------
+;; Each user-facing function comes in two flavors:
+;; - the canonical name (e.g. `patch-elements!`) is **safe by default** —
+;;   values that get written raw onto the SSE wire or into a `<script>`
+;;   tag are validated/escaped before being sent, throwing on injection.
+;; - an `unsafe-*` twin skips that validation, for the case where the
+;;   developer has already validated the input or knows the value is
+;;   trusted.
+;; The atomic helpers backing the safe path ([[assert-sse-line-safe!]],
+;; [[assert-script-body-safe!]], [[escape-script-attribute-value]],
+;; [[assert-script-attribute-name-safe!]]) are public above so that
+;; callers can also validate at a different boundary.
+
+(defn- validate-element-line-opts! [opts]
+  (when-let [v (common/id opts)]                 (assert-sse-line-safe! v "id"))
+  (when-let [v (common/selector opts)]           (assert-sse-line-safe! v "selector"))
+  (when-let [v (common/patch-mode opts)]         (assert-sse-line-safe! v "patch-mode"))
+  (when-let [v (common/element-namespace opts)]  (assert-sse-line-safe! v "element-ns"))
+  opts)
+
+
+(defn unsafe-patch-elements!
+  "Like [[patch-elements!]] but skips the safe-by-default validation of
+  option-line values. Use only when you've already validated [[id]],
+  [[selector]], [[patch-mode]] and [[element-ns]] yourself, or know they
+  are trusted.
+
+  > [!WARNING]
+  > [[id]], [[selector]], [[patch-mode]] and [[element-ns]] are written
+  > verbatim onto a single line of the SSE wire format. A `\\n` or `\\r`
+  > in any of these lets the caller inject arbitrary SSE lines (and
+  > forge whole events) into the stream."
+  ([sse-gen elements]
+   (unsafe-patch-elements! sse-gen elements {}))
+  ([sse-gen elements opts]
+   (elements/patch-elements! sse-gen elements opts)))
+
+
 (defn patch-elements!
   "Send HTML elements to the browser to be patched into the DOM.
 
@@ -284,20 +388,44 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
-  "
+
+  Safe by default: throws if [[id]], [[selector]], [[patch-mode]] or
+  [[element-ns]] contains a `\\n` or `\\r`. Use
+  [[unsafe-patch-elements!]] to skip the check."
   ([sse-gen elements]
    (patch-elements! sse-gen elements {}))
   ([sse-gen elements opts]
+   (validate-element-line-opts! opts)
    (elements/patch-elements! sse-gen elements opts)))
 
 
-(defn patch-elements-seq!
-  "Same as [[patch-elements!]] except that it takes a seq of elements."
+(defn unsafe-patch-elements-seq!
+  "Like [[patch-elements-seq!]] but skips the safe-by-default validation.
+  See [[unsafe-patch-elements!]]'s warning."
   ([sse-gen elements]
-   (patch-elements-seq! sse-gen elements {}))
+   (unsafe-patch-elements-seq! sse-gen elements {}))
   ([sse-gen elements opts]
    (elements/patch-elements-seq! sse-gen elements opts)))
 
+
+(defn patch-elements-seq!
+  "Same as [[patch-elements!]] except that it takes a seq of elements.
+
+  Safe by default; see [[unsafe-patch-elements-seq!]] to skip validation."
+  ([sse-gen elements]
+   (patch-elements-seq! sse-gen elements {}))
+  ([sse-gen elements opts]
+   (validate-element-line-opts! opts)
+   (elements/patch-elements-seq! sse-gen elements opts)))
+
+
+(defn unsafe-remove-element!
+  "Like [[remove-element!]] but skips the safe-by-default validation.
+  See [[unsafe-patch-elements!]]'s warning."
+  ([sse-gen selector]
+   (unsafe-remove-element! sse-gen selector {}))
+  ([sse-gen selector opts]
+   (elements/remove-element! sse-gen selector opts)))
 
 
 (defn remove-element!
@@ -319,11 +447,24 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
-  "
+
+  Safe by default: throws if `selector` or [[id]] contains a `\\n` or
+  `\\r`. Use [[unsafe-remove-element!]] to skip the check."
   ([sse-gen selector]
    (remove-element! sse-gen selector {}))
   ([sse-gen selector opts]
+   (assert-sse-line-safe! selector "selector")
+   (when-let [v (common/id opts)] (assert-sse-line-safe! v "id"))
    (elements/remove-element! sse-gen selector opts)))
+
+
+(defn unsafe-patch-signals!
+  "Like [[patch-signals!]] but skips the safe-by-default validation of
+  [[id]]. See [[unsafe-patch-elements!]]'s warning."
+  ([sse-gen signals-content]
+   (unsafe-patch-signals! sse-gen signals-content {}))
+  ([sse-gen signals-content opts]
+   (signals/patch-signals! sse-gen signals-content opts)))
 
 
 (defn patch-signals!
@@ -348,10 +489,13 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
-  "
+
+  Safe by default: throws if [[id]] contains a `\\n` or `\\r`. Use
+  [[unsafe-patch-signals!]] to skip the check."
   ([sse-gen signals-content]
    (patch-signals! sse-gen signals-content {}))
   ([sse-gen signals-content opts]
+   (when-let [v (common/id opts)] (assert-sse-line-safe! v "id"))
    (signals/patch-signals! sse-gen signals-content opts)))
 
 
@@ -371,6 +515,34 @@ Some scripts are provided:
   "
   [ring-request]
   (signals/get-signals ring-request))
+
+
+(defn unsafe-execute-script!
+  "Like [[execute-script!]] but skips the safe-by-default validation /
+  escaping of `script-text` and [[attributes]].
+
+  > [!WARNING]
+  > `script-text` is interpolated as raw HTML inside the `<script>` tag,
+  > and each value in [[attributes]] is interpolated raw inside a
+  > double-quoted attribute. A `</script` substring in the body or a
+  > `\\\"` in an attribute value lets the caller close the tag and
+  > inject HTML/JS."
+  ([sse-gen script-text]
+   (unsafe-execute-script! sse-gen script-text {}))
+  ([sse-gen script-text opts]
+   (scripts/execute-script! sse-gen script-text opts)))
+
+
+(defn- sanitize-script-attributes [opts]
+  (if-let [attrs (common/attributes opts)]
+    (assoc opts common/attributes
+           (reduce-kv (fn [m k v]
+                        (assoc m
+                               (assert-script-attribute-name-safe! k)
+                               (escape-script-attribute-value v)))
+                      {}
+                      attrs))
+    opts))
 
 
 (defn execute-script!
@@ -396,11 +568,20 @@ Some scripts are provided:
   Return value:
   - `false` if the connection is closed
   - `true` otherwise
-  "
+
+  Safe by default:
+  - throws if `script-text` contains `</script` (any case);
+  - throws if [[id]] contains `\\n`/`\\r`;
+  - validates each attribute name in [[attributes]] and HTML-escapes
+    each value (`& \" < >`) before they reach the script tag.
+
+  Use [[unsafe-execute-script!]] if you need to skip the validation."
   ([sse-gen script-text]
-   (scripts/execute-script! sse-gen script-text {}))
+   (execute-script! sse-gen script-text {}))
   ([sse-gen script-text opts]
-   (scripts/execute-script! sse-gen script-text opts)))
+   (assert-script-body-safe! script-text)
+   (when-let [v (common/id opts)] (assert-sse-line-safe! v "id"))
+   (scripts/execute-script! sse-gen script-text (sanitize-script-attributes opts))))
 
 
 

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/utils.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/utils.clj
@@ -57,6 +57,21 @@
   (not (string/blank? s)))
 
 
+(defn assert-no-newline!
+  "Throw an [[ex-info]] if `(str v)` contains `\\n` or `\\r`.
+
+  Used to defend against SSE event injection: option/id values are written
+  to a single line of the SSE wire format, so a newline in user-controlled
+  input would let an attacker append arbitrary lines (and forge whole
+  events). `name` is included in the error for context. Returns `(str v)`."
+  [v ^String name]
+  (let [s (str v)]
+    (when (or (.contains s "\n") (.contains s "\r"))
+      (throw (ex-info (str name " must not contain newlines or carriage returns.")
+                      {:value v :name name})))
+    s))
+
+
 (defn merge-transient!
   "Merge a map `m` into a transient map `tm`.
   Returns the transient map without calling [[persistent!]] on it."

--- a/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
+++ b/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
@@ -354,3 +354,147 @@
 
 (comment
   (ltr/run-test-var #'test-execute-script!))
+
+
+;; -----------------------------------------------------------------------------
+;; Sanitizer helpers
+;; -----------------------------------------------------------------------------
+;; The atomic helpers backing the safe-by-default validation, exposed so
+;; callers can also validate at a different boundary.
+(defn- threw? [thunk]
+  (try (thunk) false (catch Exception _ true)))
+
+(defdescribe test-assert-sse-line-safe!
+  (describe d*/assert-sse-line-safe!
+    (specify "passes through clean values"
+      (expect (= "1" (d*/assert-sse-line-safe! "1" "id")))
+      (expect (= "#main" (d*/assert-sse-line-safe! "#main" "selector")))
+      (expect (= "" (d*/assert-sse-line-safe! "" "id"))))
+    (specify "coerces to string"
+      (expect (= "42" (d*/assert-sse-line-safe! 42 "id"))))
+    (specify "throws on \\n"
+      (expect (threw? #(d*/assert-sse-line-safe! "1\nevent: bad" "id"))))
+    (specify "throws on \\r"
+      (expect (threw? #(d*/assert-sse-line-safe! "1\rmalicious" "id"))))
+    (specify "throws on \\r\\n"
+      (expect (threw? #(d*/assert-sse-line-safe! "x\r\ny" "selector"))))))
+
+
+(defdescribe test-assert-script-body-safe!
+  (describe d*/assert-script-body-safe!
+    (specify "passes through clean script bodies"
+      (expect (= "alert(1)" (d*/assert-script-body-safe! "alert(1)")))
+      (expect (= "" (d*/assert-script-body-safe! ""))))
+    (specify "lenient on non-string (consistent with execute-script! type expectations)"
+      (expect (= :test (d*/assert-script-body-safe! :test))))
+    (specify "throws on </script (lowercase)"
+      (expect (threw? #(d*/assert-script-body-safe! "</script>"))))
+    (specify "throws on </SCRIPT (any case)"
+      (expect (threw? #(d*/assert-script-body-safe! "x; </ScRiPt foo"))))))
+
+
+(defdescribe test-escape-script-attribute-value
+  (describe d*/escape-script-attribute-value
+    (specify "passes through clean values"
+      (expect (= "module" (d*/escape-script-attribute-value "module")))
+      (expect (= "" (d*/escape-script-attribute-value ""))))
+    (specify "coerces to string"
+      (expect (= "1" (d*/escape-script-attribute-value 1))))
+    (specify "escapes the four HTML attribute-context characters"
+      (expect (= "a&quot;b" (d*/escape-script-attribute-value "a\"b")))
+      (expect (= "&amp;" (d*/escape-script-attribute-value "&")))
+      (expect (= "&lt;a&gt;" (d*/escape-script-attribute-value "<a>"))))
+    (specify "escapes & before quotes (no double-escape)"
+      (expect (= "&amp;quot;" (d*/escape-script-attribute-value "&quot;"))))))
+
+
+(defdescribe test-assert-script-attribute-name-safe!
+  (describe d*/assert-script-attribute-name-safe!
+    (specify "accepts valid names"
+      (expect (= "type" (d*/assert-script-attribute-name-safe! "type")))
+      (expect (= "data-x" (d*/assert-script-attribute-name-safe! :data-x)))
+      (expect (= "x:y" (d*/assert-script-attribute-name-safe! "x:y"))))
+    (specify "throws on names with whitespace or =\""
+      (expect (threw? #(d*/assert-script-attribute-name-safe! "x onclick=foo")))
+      (expect (threw? #(d*/assert-script-attribute-name-safe! "x\"y"))))
+    (specify "throws on empty"
+      (expect (threw? #(d*/assert-script-attribute-name-safe! ""))))))
+
+
+(comment
+  (ltr/run-test-var #'test-assert-sse-line-safe!)
+  (ltr/run-test-var #'test-assert-script-body-safe!)
+  (ltr/run-test-var #'test-escape-script-attribute-value)
+  (ltr/run-test-var #'test-assert-script-attribute-name-safe!))
+
+
+;; -----------------------------------------------------------------------------
+;; Safe-by-default behavior
+;; -----------------------------------------------------------------------------
+;; The five public patch/script functions validate their option-line and
+;; script inputs by default. The `unsafe-*` twins skip the validation.
+(defdescribe test-safe-by-default-rejects-injection
+  (describe "patch-elements! rejects newlines in option lines"
+    (specify "id"
+      (expect (threw? #(d*/patch-elements! (at/->sse-gen) "x" {d*/id "1\nevent: bad"}))))
+    (specify "selector"
+      (expect (threw? #(d*/patch-elements! (at/->sse-gen) "x" {d*/selector "x\nevent: bad"}))))
+    (specify "patch-mode"
+      (expect (threw? #(d*/patch-elements! (at/->sse-gen) "x" {d*/patch-mode "after\nevent: bad"}))))
+    (specify "element-ns"
+      (expect (threw? #(d*/patch-elements! (at/->sse-gen) "x" {d*/element-ns "svg\nevent: bad"})))))
+
+  (describe "patch-elements-seq! rejects newlines"
+    (specify "selector"
+      (expect (threw? #(d*/patch-elements-seq! (at/->sse-gen) ["x"] {d*/selector "x\ny"})))))
+
+  (describe "remove-element! rejects newlines"
+    (specify "selector positional arg"
+      (expect (threw? #(d*/remove-element! (at/->sse-gen) "#x\nevent: bad"))))
+    (specify "id"
+      (expect (threw? #(d*/remove-element! (at/->sse-gen) "#x" {d*/id "1\nbad"})))))
+
+  (describe "patch-signals! rejects newlines"
+    (specify "id"
+      (expect (threw? #(d*/patch-signals! (at/->sse-gen) "{}" {d*/id "1\nbad"})))))
+
+  (describe "execute-script! defends the script tag"
+    (specify "rejects </script in body (lowercase)"
+      (expect (threw? #(d*/execute-script! (at/->sse-gen) "</script>"))))
+    (specify "rejects </SCRIPT in body (any case)"
+      (expect (threw? #(d*/execute-script! (at/->sse-gen) "x; </ScRiPt foo"))))
+    (specify "escapes attribute values"
+      (expect (= (d*/execute-script! (at/->sse-gen) "x"
+                                     {d*/auto-remove false
+                                      d*/attributes {"data-x" "a\" data-evil=\"x"}})
+                 (script-event
+                   "<script data-x=\"a&quot; data-evil=&quot;x\">x</script>"))))
+    (specify "rejects malformed attribute names"
+      (expect (threw? #(d*/execute-script! (at/->sse-gen) "x"
+                                           {d*/attributes {"x onclick=foo" "1"}}))))))
+
+
+(defdescribe test-unsafe-variants-skip-validation
+  (describe "unsafe-* twins do not validate"
+    (specify "unsafe-patch-elements! lets the injected line through"
+      (let [out (d*/unsafe-patch-elements! (at/->sse-gen) "x" {d*/id "1\nevent: bad"})]
+        (expect (.contains ^String out "id: 1\nevent: bad"))))
+
+    (specify "unsafe-patch-signals! lets the injected line through"
+      (let [out (d*/unsafe-patch-signals! (at/->sse-gen) "{}" {d*/id "1\nbad"})]
+        (expect (.contains ^String out "id: 1\nbad"))))
+
+    (specify "unsafe-remove-element! lets the injected selector through"
+      (let [out (d*/unsafe-remove-element! (at/->sse-gen) "#x\nevent: bad")]
+        (expect (.contains ^String out "selector #x\nevent: bad"))))
+
+    (specify "unsafe-execute-script! does not escape attribute values"
+      (let [out (d*/unsafe-execute-script! (at/->sse-gen) "alert(1)"
+                                           {d*/auto-remove false
+                                            d*/attributes {"data-x" "a\" b"}})]
+        (expect (.contains ^String out "data-x=\"a\" b\""))))))
+
+
+(comment
+  (ltr/run-test-var #'test-safe-by-default-rejects-injection)
+  (ltr/run-test-var #'test-unsafe-variants-skip-validation))


### PR DESCRIPTION
## Status: proposal — alternative design to #32

Filed as a separate proposal because @JeremS has indicated in #32 that he prefers opt-in helpers + docstring warnings over baked-in validation. I respect that call; this PR is a sketch of the alternative for evaluation, not a request to override that decision. Reasonable people can disagree here, and either design is shippable.

## Design

The five user-facing patch/script functions become safe by default — they validate / escape values that get written raw onto the SSE wire or into a `<script>` tag, throwing on inputs that would inject extra SSE lines or close the tag. Each has an `unsafe-*` twin that preserves the current behavior, for callers who have already validated their input or know the value is trusted.

```clojure
;; safe (default): throws on \n in id
(d*/patch-elements! sse-gen html {d*/id user-supplied-id})

;; explicit opt-out
(d*/unsafe-patch-elements! sse-gen html {d*/id pre-validated-id})
```

Atomic helpers backing the safe path are public, so callers can validate at a different boundary or pre-validate before calling an `unsafe-*` variant:
- `assert-sse-line-safe!`
- `assert-script-body-safe!`
- `escape-script-attribute-value`
- `assert-script-attribute-name-safe!`

## Why I think safe-by-default is worth considering

**1. The validations only reject inputs that are *already* spec violations.** SSE id/event lines are single-line by spec. CSS selectors don't span lines. HTML attribute names can't contain whitespace. `</script` (any case) always closes a script tag regardless of escaping. No legitimate caller is broken — the only inputs rejected are ones that would silently corrupt the output anyway.

**2. \"Developer-controlled\" is a fuzzy claim in modern apps.** A few realistic patterns where user data flows into these fields without anyone consciously thinking about it:
- `id` ← `(str \"msg-\" (:request-id req))` — request-id originates client-side.
- `selector` ← `(str \"#row-\" username)` — username from auth.
- `attributes` map values — `data-user-name`, `data-href`, etc. The whole point of `data-*` attributes is to carry arbitrary data.

In each case the burden of remembering \"this can carry user input, validate it\" sits at every call site. Safe-by-default flips that: callers have to *deliberately* opt out, which is much rarer.

**3. Asymmetric cost.** Validation is one regex per call (~10 ns). The cost of getting it wrong is a CVE on a security-adjacent library. That asymmetry is the same reason parameterized SQL beat string-concatenated SQL, and why Hiccup / React / Selmer / every modern HTML library escape by default.

**4. The Go / PHP SDK precedent.** Lateral conformity is a reasonable starting point, but \"the others don't either\" is a weak design argument; it perpetuates a default rather than justifying it. If a vulnerability were ever reported against any of those SDKs, all of them would likely move in this direction at once.

## Where I think the maintainer's view holds up

- It's the project's call. Library authors get to set the contract. Disagreeing on technical merit doesn't override that.
- The attribute *escaping* (not the validation — the auto-transform of `&` `\"` etc.) is a behavior change that could surprise a developer who happened to want a literal `&` or `<` in an attribute. This PR mitigates by exposing `unsafe-execute-script!` and `escape-script-attribute-value` for explicit control, but it's still a real concern.
- `unsafe-*` doubles the API surface to document and maintain. That's a legitimate tax.
- This is RC; some users may be relying on existing permissive behavior (though I'd argue no *correct* code can be).

## Test plan
- [x] `bb test:bb` — 78/78 pass (existing tests + 16 new specs covering safe-rejection across all five functions and pass-through across the four `unsafe-*` twins).
- [x] No diff vs `main` outside `api.clj` (sanitizers, safe wrappers, `unsafe-*` twins), `utils.clj` (private helper), and `api_test.clj` (tests).

## Disposition

Happy with whatever you decide:
- **Accept this PR** — close #32 (which has the previous, opt-in design), this becomes the contract for 1.0.
- **Reject this PR, accept #32** — your judgment, no hard feelings; opt-in helpers + docstring warnings is a perfectly defensible design.
- **Reject both, accept only the brotli charset (#35)** — also fine. I'll continue to use the safe-by-default version on my fork.