### PR TITLE
Refactor: rework sse-gen closing, specifically error management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release notes for the Clojure SDK
 
+## 2026-05-01 - RC10
+### Changed
+- The code handling exceptions arising when closing a sse generator has been
+  redesigned. Errors are thrown as is, exceptions are wrapped in an ExceptionInfo
+  whose `ex-data` contains an exception thrown during the closing of IO resources
+  and/or an exception thrown during the on-close callback.
+  See the `closing-io-exception` and `closing-on-close-exception` vars in your
+  adapter namespace to get at a specific exception. See the docstring for
+  `starfederation.datastar.clojure.adapter.common/close-sse!` for more
+  information about the whole sse-gen closing process.
+
 ## 2026-04-20 - RC9
 ### Changed
 - The CDN urls now point to the latest 1.0.1 release of Datastar.

--- a/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph.clj
+++ b/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph.clj
@@ -10,6 +10,8 @@
 (def-clone on-exception ac/on-exception)
 (def-clone default-on-exception ac/default-on-exception)
 
+(def-clone closing-io-exception ac/closing-io-exception)
+(def-clone closing-on-close-exception ac/closing-on-close-exception)
 
 (def-clone write-profile ac/write-profile)
 

--- a/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph/impl.clj
+++ b/libraries/sdk-aleph/src/main/starfederation/datastar/clojure/adapter/aleph/impl.clj
@@ -85,18 +85,17 @@
 
   (close-sse! [this]
     (u/lock! lock
+      ;; on-close serves as a sentinel. That way when the user closes the
+      ;; SSEGenerator (as opposed to the browser) we don't close again when
+      ;; the manifold stream on-closed callback is called
       (if on-close
-        (let [closing-res (ac/close-sse! #(do (send!))
-                                         #(when on-close (on-close this)))]
+        (try
+          (ac/close-sse! #(do (send!))
+                         #(when on-close (on-close this)))
 
-          ;; on-close serves as a sentinel, that way when
-          ;; the user close the SSEGenerator is closed (as opposed to the browser)
-          ;; we don't close again when the manifold stream on-closed callback is called
-          (set! on-close nil)
-          (s/close! stream)
-          (if (instance? Exception closing-res)
-            (throw closing-res)
-            closing-res))
+          (finally
+            (set! on-close nil)
+            (s/close! stream)))
         false)))
 
   (sse-gen? [_] true)

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -69,11 +69,7 @@
 
        :on-close
        (fn [_ status]
-         (let [closing-res
-               (ac/close-sse!
-                #(when-let [send! (deref future-send! 0 nil)] (send!))
-                #(when on-close-cb
-                   (on-close-cb (deref future-gen 0 nil) status)))]
-           (if (instance? Exception closing-res)
-             (throw closing-res)
-             closing-res)))})))
+         (ac/close-sse!
+          #(when-let [send! (deref future-send! 0 nil)] (send!))
+          #(when on-close-cb
+             (on-close-cb (deref future-gen 0 nil) status))))})))

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -11,6 +11,8 @@
 (def-clone on-exception ac/on-exception)
 (def-clone default-on-exception ac/default-on-exception)
 
+(def-clone closing-io-exception ac/closing-io-exception)
+(def-clone closing-on-close-exception ac/closing-on-close-exception)
 
 (def-clone write-profile ac/write-profile)
 

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
@@ -87,14 +87,11 @@
 
          :on-close
          (fn [_ status]
-           (let [closing-res
-                 (ac/close-sse!
-                  #(when-let [send! (deref future-send! 0 nil)] (send!))
-                  #(when on-close-cb
-                     (on-close-cb (deref future-gen 0 nil) status)))]
-             (if (instance? Exception closing-res)
-               (throw closing-res)
-               closing-res)))})
+           (ac/close-sse!
+            #(when-let [send! (deref future-send! 0 nil)] (send!))
+            #(when on-close-cb
+               (on-close-cb (deref future-gen 0 nil) status))))})
+
       :status (or status 200)
       :headers (ac/headers ring-request opts)
       ::datastar-sse-response true)))

--- a/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
+++ b/libraries/sdk-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit2.clj
@@ -11,6 +11,8 @@
 (def-clone on-exception ac/on-exception)
 (def-clone default-on-exception ac/default-on-exception)
 
+(def-clone closing-io-exception ac/closing-io-exception)
+(def-clone closing-on-close-exception ac/closing-on-close-exception)
 
 (def-clone write-profile ac/write-profile)
 

--- a/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -10,6 +10,8 @@
 (def-clone on-exception ac/on-exception)
 (def-clone default-on-exception ac/default-on-exception)
 
+(def-clone closing-io-exception ac/closing-io-exception)
+(def-clone closing-on-close-exception ac/closing-on-close-exception)
 
 (def-clone write-profile ac/write-profile)
 

--- a/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/libraries/sdk-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -77,14 +77,13 @@
     (u/lock! lock
       ;; If either send! or on-close are here we try to close them
       (if (or send! on-close)
-        (let [res (ac/close-sse! #(when send! (send!))
-                                 #(when on-close (on-close this)))]
+        (try
+          (ac/close-sse! #(when send! (send!))
+                         #(when on-close (on-close this)))
           ;; We make sure to clean them up after closing
-          (set! send! nil)
-          (set! on-close nil)
-          (if (instance? Exception res)
-            (throw res)
-            true))
+          (finally
+            (set! send! nil)
+            (set! on-close nil)))
         false)))
 
   (sse-gen? [_] true)

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -304,7 +304,7 @@
 ;; -----------------------------------------------------------------------------
 (defn try-thunk
   "Run a thunk `f` catching any [[Throwable]]. Returns either the result or
-  the caught[[Throwable]]."
+  the caught [[Throwable]]."
   [f]
   (try (f) (catch Throwable t t)))
 
@@ -314,13 +314,13 @@
 
 (def closing-io-exception
   "Key used to get the exception thrown while closing io resources during
-   the closing of a sse-gen. See [[close-sse!]]."
+  the closing of a sse-gen. See [[close-sse!]]."
   :d*.sse/closing-io-exception)
 
 
 (def closing-on-close-exception
   "Key used to get the exception thrown while calling the on-close callback
-   during the closing of a sse-gen. See [[close-sse!]]."
+  during the closing of a sse-gen. See [[close-sse!]]."
   :d*.sse/closing-on-close-exception)
 
 

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -356,18 +356,6 @@
         (throw (ex-info "Error closing the sse-gen." exceptions))
         true))))
 
-(comment
-  (close-sse! #(do 1)                    #(do 2))
-  (close-sse! #(throw (Error. "e1"))     #(do 2))
-  (close-sse! #(do 1)                    #(throw (Error. "e2")))
-  (close-sse! #(throw (Error. "e1"))     #(throw (Error. "e2")))
-  (close-sse! #(throw (Error. "e1"))     #(throw (Exception. "e2")))
-  (close-sse! #(throw (Exception. "e1")) #(throw (Error. "e2")))
-
-  (close-sse! #(throw (Exception. "e1")) #(do 2))
-  (close-sse! (fn [] 1)                  #(throw (Exception. "e2")))
-  (close-sse! #(throw (Exception. "e1")) #(throw (Exception. "e2"))))
-
 
 ;; -----------------------------------------------------------------------------
 ;; Callbacks

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -302,71 +302,77 @@
 ;; -----------------------------------------------------------------------------
 ;; Exception handling / Closing sse helpers
 ;; -----------------------------------------------------------------------------
-(defn try-closing
-  "Run a thunk `f` that closes some resources. Catches exceptions and returns
-  them wrapped in a [[ex-info]] with the message `error-msg`."
-  [f error-msg]
-  (try
-    (f)
-    (catch Throwable t
-      (ex-info error-msg {} t))))
+(defn try-thunk
+  "Run a thunk `f` catching any [[Throwable]]. Returns either the result or
+  the caught[[Throwable]]."
+  [f]
+  (try (f) (catch Throwable t t)))
 
 
-(def closing-exceptions
-  "Exceptions caught while closing a sse generator using [[close-sse!]]
-  are grouped under this key in the ex-info's data that is returned."
-  :d*.sse/closing-exceptions)
+(defn- error? [x] (instance? Error x))
+(defn- exception? [x] (instance? Exception x))
+
+(def closing-io-exception
+  "Key used to get the exception thrown while closing io resources during
+   the closing of a sse-gen. See [[close-sse!]]."
+  :d*.sse/closing-io-exception)
 
 
-(defn- group-exceptions [closing-results]
-  (group-by (fn [v] (cond
-                      (instance? Exception v) :exceptions
-                      (instance? Throwable v) :throwables
-                      :else                   :irrelevant))
-            closing-results))
-
-(comment
-  (group-exceptions [(Error.) (ex-info "" {})])
-  (group-exceptions [:a (ex-info "" {})])
-  (group-exceptions [:a (Error.)]))
+(def closing-on-close-exception
+  "Key used to get the exception thrown while calling the on-close callback
+   during the closing of a sse-gen. See [[close-sse!]]."
+  :d*.sse/closing-on-close-exception)
 
 
 (defn close-sse!
   "Closing a sse-gen is a 2 steps process.
+
   1. close IO resources calling the `close-io!` thunk.
   2. call the sse-gen's `on-close` callback by calling the `on-close!` thunk.
 
-  Both thunks are called using [[try-closing]] to capture exceptions.
+  Both thunks are called using [[try-thunk]] to capture [[Throwable]] and are
+  guaranteed to run once.
 
-  This function rethrows the first `java.lang.Throwable` encountered. Otherwise
-  it returns either `true` when all thunks are exceptions free or an
-  exception created with [[ex-info]] that contains the thunks exceptions in it's
-  data under the key [[closing-exceptions]]."
+  Returns `true` when both thunks complete without throwing.
+
+  The first [[java.lang.Error]] returned by a thunk is re-thrown.
+
+  If the thunks have thrown exceptions (not errors), these are grouped inside
+  the data of an exception created with [[ex-info]] under the keys
+  [[closing-io-exception]] and [[closing-on-close-exception]].
+  That ex-info is then thrown.
+  "
   [close-io! on-close!]
-  (let [results [(try-closing close-io! "Error closing the output stream.")
-                 (try-closing on-close! "Error calling the on close callback.")]
+  (let [close-io-res (try-thunk close-io!)
+        on-close-res (try-thunk on-close!)]
 
-        {:keys [throwables exceptions]} (group-exceptions results)
-        throwable (some identity throwables)]
-    (cond
-      throwable        (throw throwable)
-      (seq exceptions) (ex-info "Error closing the sse-gen."
-                                {closing-exceptions exceptions})
-      :else            true)))
+    (when (error? close-io-res) (throw close-io-res))
+    (when (error? on-close-res) (throw on-close-res))
 
-
-(defn get-closing-exceptions
-  "Extract the exceptions in the `ex-data` of a ex-info thrown during the
-  closing of a sse generator."
-  [e]
-  (-> e ex-data closing-exceptions))
+    (let [exceptions (cond-> {}
+                       (exception? close-io-res) (assoc closing-io-exception close-io-res)
+                       (exception? on-close-res) (assoc closing-on-close-exception on-close-res))]
+      (if (empty? exceptions)
+        true
+        (ex-info "Error closing the sse-gen." exceptions)))))
 
 
 (comment
-  (-> (ex-info "msg" {closing-exceptions [:e1 :e2]})
-      get-closing-exceptions))
+  (try-thunk (fn [] (close-sse! #(do 1)                    #(do 2))))
+  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(do 2))))
+  (try-thunk (fn [] (close-sse! #(do 1)                     #(throw (Error. "e2")))))
+  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(throw (Error. "e2")))))
+  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(throw (Exception. "e2")))))
+  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(throw (Error. "e2")))))
+
+  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(do 2))))
+  (try-thunk (fn [] (close-sse! (fn [] 1)                  #(throw (Exception. "e2")))))
+  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(throw (Exception. "e2"))))))
 
 
+;; -----------------------------------------------------------------------------
+;; Callbacks
+;; -----------------------------------------------------------------------------
 (def on-open
   "SSE option key:
 

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -358,16 +358,16 @@
 
 
 (comment
-  (try-thunk (fn [] (close-sse! #(do 1)                    #(do 2))))
-  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(do 2))))
-  (try-thunk (fn [] (close-sse! #(do 1)                     #(throw (Error. "e2")))))
-  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(throw (Error. "e2")))))
-  (try-thunk (fn [] (close-sse! #(throw (Error. "e1"))     #(throw (Exception. "e2")))))
-  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(throw (Error. "e2")))))
+  (close-sse! #(do 1)                    #(do 2))
+  (close-sse! #(throw (Error. "e1"))     #(do 2))
+  (close-sse! #(do 1)                     #(throw (Error. "e2")))
+  (close-sse! #(throw (Error. "e1"))     #(throw (Error. "e2")))
+  (close-sse! #(throw (Error. "e1"))     #(throw (Exception. "e2")))
+  (close-sse! #(throw (Exception. "e1")) #(throw (Error. "e2")))
 
-  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(do 2))))
-  (try-thunk (fn [] (close-sse! (fn [] 1)                  #(throw (Exception. "e2")))))
-  (try-thunk (fn [] (close-sse! #(throw (Exception. "e1")) #(throw (Exception. "e2"))))))
+  (close-sse! #(throw (Exception. "e1")) #(do 2))
+  (close-sse! (fn [] 1)                  #(throw (Exception. "e2")))
+  (close-sse! #(throw (Exception. "e1")) #(throw (Exception. "e2"))))
 
 
 ;; -----------------------------------------------------------------------------

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -352,15 +352,14 @@
     (let [exceptions (cond-> {}
                        (exception? close-io-res) (assoc closing-io-exception close-io-res)
                        (exception? on-close-res) (assoc closing-on-close-exception on-close-res))]
-      (if (empty? exceptions)
-        true
-        (throw (ex-info "Error closing the sse-gen." exceptions))))))
-
+      (if (seq exceptions)
+        (throw (ex-info "Error closing the sse-gen." exceptions))
+        true))))
 
 (comment
   (close-sse! #(do 1)                    #(do 2))
   (close-sse! #(throw (Error. "e1"))     #(do 2))
-  (close-sse! #(do 1)                     #(throw (Error. "e2")))
+  (close-sse! #(do 1)                    #(throw (Error. "e2")))
   (close-sse! #(throw (Error. "e1"))     #(throw (Error. "e2")))
   (close-sse! #(throw (Error. "e1"))     #(throw (Exception. "e2")))
   (close-sse! #(throw (Exception. "e1")) #(throw (Error. "e2")))

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -354,7 +354,7 @@
                        (exception? on-close-res) (assoc closing-on-close-exception on-close-res))]
       (if (empty? exceptions)
         true
-        (ex-info "Error closing the sse-gen." exceptions)))))
+        (throw (ex-info "Error closing the sse-gen." exceptions))))))
 
 
 (comment

--- a/src/test/core-sdk/starfederation/datastar/clojure/adapter/common_test.clj
+++ b/src/test/core-sdk/starfederation/datastar/clojure/adapter/common_test.clj
@@ -1,5 +1,6 @@
 (ns starfederation.datastar.clojure.adapter.common-test
   (:require
+    [matcher-combinators.test :refer [thrown-match?]]
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.adapter.test :as at]
@@ -74,7 +75,7 @@
 
 
 ;; -----------------------------------------------------------------------------
-;; Tests
+;; Write profiles tests
 ;; -----------------------------------------------------------------------------
 (defn simple-round-trip [write-profile]
   (let [!res (atom nil)
@@ -149,6 +150,42 @@
           (expect (= @!res "some textsome other text"))))))
 
 
+;; -----------------------------------------------------------------------------
+;; Closing tests
+;; -----------------------------------------------------------------------------
+(def io-error (Error. "io"))
+(def oc-error (Error. "on-close"))
+
+(def io-exception (Exception. "io"))
+(def oc-exception (Exception. "on-close"))
+
+(def dummy-thunk (constantly true))
+
+(defmacro throws-error? [expected expr]
+  `(= ~expected
+      (try ~expr :no-throw (catch Throwable t# t#))))
+
+(defmacro throws-exception? [expected-data expr]
+  `(= ~expected-data
+      (try ~expr :no-throw (catch Exception e# (ex-data e#)))))
+
+(defdescribe closing-behavior
+  (specify "No exception/error returns true"
+    (expect (true? (ac/close-sse! dummy-thunk dummy-thunk))))
+
+  (specify "First error wins"
+    (expect (throws-error? io-error (ac/close-sse! #(throw io-error)     dummy-thunk)))
+    (expect (throws-error? oc-error (ac/close-sse! dummy-thunk           #(throw oc-error))))
+    (expect (throws-error? io-error (ac/close-sse! #(throw io-error)     #(throw oc-exception))))
+    (expect (throws-error? oc-error (ac/close-sse! #(throw io-exception) #(throw oc-error))))
+    (expect (throws-error? io-error (ac/close-sse! #(throw io-error)     #(throw oc-error)))))
+
+  (specify "Exception are caught and grouped"
+    (expect (throws-exception? {ac/closing-io-exception io-exception}        (ac/close-sse! #(throw io-exception) dummy-thunk)))
+    (expect (throws-exception? {ac/closing-on-close-exception oc-exception}  (ac/close-sse! dummy-thunk           #(throw oc-exception))))
+    (expect (throws-exception?  {ac/closing-io-exception io-exception
+                                 ac/closing-on-close-exception oc-exception} (ac/close-sse! #(throw io-exception) #(throw oc-exception))))))
+
 (comment
   :dbg
   :rec
@@ -157,4 +194,3 @@
   (ltr/run-test-var #'reading-bytes)
   (ltr/run-test-var #'normal)
   (ltr/run-test-var #'gzip))
-


### PR DESCRIPTION
@Ramblurr @andriytyurnikov 

I went ahead and created an alternative to #30.

The goal is to make sure the SDK tries to close IO resources and calls the on-close callback when a sse-gen is closed. The exception management is what I had in mind at the beginning but messed up.

With this code :
- Errors stay error, are re-thrown as is and trump everything
- Exceptions (if not errors) are grouped into one ex-info and re-thrown
- Both IO resource closing and user callback are called once even in the presence of errors
- I am using the try-finally pattern from #30, it's cleaner than what I had.

Cheers,