### PR TITLE
Feature: support for the view-transition-selector option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release notes for the Clojure SDK
 
+## 2026-06-03 - RC11
+### Added
+- The new `view-transition-selector` option for patch elements functions that
+  was introduced in Datastar v1.0.2 is now supported.
+  
+### Changed
+- The Datastar CDN url provided in the api now points to Datastar v1.0.2
+
+
 ## 2026-05-01 - RC10
 ### Changed
 - The code handling exceptions arising when closing a sse generator has been

--- a/libraries/sdk-malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
+++ b/libraries/sdk-malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
@@ -64,6 +64,7 @@
        [common/selector :string]
        [common/patch-mode patch-modes-schema]
        [common/use-view-transition :boolean]
+       [common/view-transition-selector :string]
        [common/element-namespace element-namespaces-schema]])))
 
 ;; -----------------------------------------------------------------------------

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -16,6 +16,7 @@ These function take options map whose keys are:
 - [[selector]]
 - [[patch-mode]]
 - [[use-view-transition]]
+- [[view-transition-selector]]
 - [[element-ns]]
 - [[only-if-missing]]
 - [[auto-remove]]
@@ -55,14 +56,14 @@ Some scripts are provided:
 ;; -----------------------------------------------------------------------------
 (def CDN-url
   "URL for the Datastar js bundle tracking the latest Datastar, currently
-  v1.0.1."
+  v1.0.2."
 
-  "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js")
+  "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js")
 
 
 (def CDN-map-url
   "URL for the Datastar source map going with [[CDN-url]]."
-  "https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js.map")
+  "https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.2/bundles/datastar.js.map")
 
 ;; -----------------------------------------------------------------------------
 ;; SSE generator management
@@ -182,6 +183,13 @@ Some scripts are provided:
   Datastar client side will default to false."
   common/use-view-transition)
 
+(def view-transition-selector
+  "[[patch-elements!]] / [[remove-element!]  option, string:
+
+  Selector used for the view transitions API. This option is
+  applied only if [[use-view-transition]] is true.
+  "
+  common/view-transition-selector)
 
 (def element-ns
   "[[patch-elements!]] & [[patch-elements-seq!]] option, boolean:
@@ -279,6 +287,7 @@ Some scripts are provided:
   - [[selector]]
   - [[patch-mode]]
   - [[use-view-transition]]
+  - [[view-transition-selector]]
   - [[element-ns]]
 
   Return value:
@@ -315,6 +324,7 @@ Some scripts are provided:
   - [[id]]
   - [[retry-duration]]
   - [[use-view-transition]]
+  - [[view-transition-selector]]
 
   Return value:
   - `false` if the connection is closed

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api/common.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api/common.clj
@@ -9,10 +9,11 @@
 (def retry-duration      :d*.sse/retry-duration)
 
 ;; Merge fragment opts
-(def selector            :d*.elements/selector)
-(def patch-mode          :d*.elements/patch-mode)
-(def use-view-transition :d*.elements/use-view-transition)
-(def element-namespace   :d*.elements/namespace)
+(def selector                 :d*.elements/selector)
+(def patch-mode               :d*.elements/patch-mode)
+(def use-view-transition      :d*.elements/use-view-transition)
+(def view-transition-selector :d*.elements/view-transition-selector)
+(def element-namespace        :d*.elements/namespace)
 
 ;;Signals opts
 (def only-if-missing     :d*.signals/only-if-missing)

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/api/elements.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/api/elements.clj
@@ -18,6 +18,9 @@
 (defn- add-view-transition? [v]
   (common/add-boolean-option? consts/default-elements-use-view-transitions v))
 
+(defn- add-view-transition-selector? [use-view-transition selector]
+  (and use-view-transition (u/not-empty-string? selector)))
+
 (defn add-namespace? [namespace]
   (not= consts/default-element-namespace namespace))
 
@@ -28,7 +31,8 @@
   (let [sel (common/selector opts)
         patch-mode (common/patch-mode opts)
         use-vt (common/use-view-transition opts)
-        namespace (common/element-namespace opts)]
+        namespace (common/element-namespace opts)
+        vt-sel (common/view-transition-selector opts)]
 
     (cond-> data-lines!
       (and sel (valid-selector? sel))
@@ -39,6 +43,9 @@
 
       (and use-vt (add-view-transition? use-vt))
       (common/add-opt-line! consts/use-view-transition-dataline-literal use-vt)
+
+      (and vt-sel (add-view-transition-selector? use-vt vt-sel))
+      (common/add-opt-line! consts/view-transition-selector-dataline-literal vt-sel)
 
       (and namespace (add-namespace? namespace))
       (common/add-opt-line! consts/namespace-dataline-literal namespace))))
@@ -139,10 +146,12 @@
   (= (->patch-elements-seq ["<div>hello</div> \n<div>world!!!</div>" "<div>world!!!</div>"]
                        {common/selector "#toto"
                         common/patch-mode consts/element-patch-mode-after
-                        common/use-view-transition true})
+                        common/use-view-transition true
+                        common/view-transition-selector "#id"})
      ["selector #toto"
       "mode after"
       "useViewTransition true"
+      "viewTransitionSelector #id"
       "elements <div>hello</div> "
       "elements <div>world!!!</div>"
       "elements <div>world!!!</div>"]))

--- a/libraries/sdk/src/main/starfederation/datastar/clojure/consts.clj
+++ b/libraries/sdk/src/main/starfederation/datastar/clojure/consts.clj
@@ -16,13 +16,14 @@
 ;; -----------------------------------------------------------------------------
 ;; Dataline literals
 ;; -----------------------------------------------------------------------------
-(def selector-dataline-literal "selector ")
-(def mode-dataline-literal "mode ")
-(def elements-dataline-literal "elements ")
-(def use-view-transition-dataline-literal "useViewTransition ")
-(def signals-dataline-literal "signals ")
-(def only-if-missing-dataline-literal "onlyIfMissing ")
-(def namespace-dataline-literal "namespace ")
+(def selector-dataline-literal                 "selector ")
+(def mode-dataline-literal                     "mode ")
+(def elements-dataline-literal                 "elements ")
+(def use-view-transition-dataline-literal      "useViewTransition ")
+(def view-transition-selector-dataline-literal "viewTransitionSelector ")
+(def signals-dataline-literal                  "signals ")
+(def only-if-missing-dataline-literal          "onlyIfMissing ")
+(def namespace-dataline-literal                "namespace ")
 
 
 ;; -----------------------------------------------------------------------------

--- a/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
+++ b/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
@@ -99,6 +99,9 @@
 (def use-view-transition-line
   (->data-line consts/use-view-transition-dataline-literal true))
 
+(def view-transition-selector-line
+  (->data-line consts/view-transition-selector-dataline-literal "#selector"))
+
 (def test-namespace consts/element-namespace-svg)
 (def namespace-line
   (->data-line consts/namespace-dataline-literal test-namespace))
@@ -148,6 +151,23 @@
   (expect (= (tested-patch-fn (at/->sse-gen) input {d*/use-view-transition true})
              (event patch-element-t (list* use-view-transition-line expected-datalines)))))
 
+(defn patch-vt-false-vtsel-test
+  "No view transition selector when view transition is false."
+  [tested-patch-fn input expected-datalines]
+  (expect (= (tested-patch-fn (at/->sse-gen) input {d*/use-view-transition false d*/view-transition-selector "#selector"})
+             (event patch-element-t expected-datalines))))
+
+(defn patch-vt-true-vtsel-empty-test
+  "View transition line is added on true, selector being empty isn't."
+  [tested-patch-fn input expected-datalines]
+  (expect (= (tested-patch-fn (at/->sse-gen) input {d*/use-view-transition true d*/view-transition-selector ""})
+             (event patch-element-t (list* use-view-transition-line expected-datalines)))))
+
+(defn patch-vt-true-vtsel-test
+  "View transition line is added and the selector is added."
+  [tested-patch-fn input expected-datalines]
+  (expect (= (tested-patch-fn (at/->sse-gen) input {d*/use-view-transition true d*/view-transition-selector "#selector"})
+             (event patch-element-t (list* use-view-transition-line view-transition-selector-line expected-datalines)))))
 
 (defn patch-ns-html-test
   "Patch-elements test case using the default namespace."
@@ -207,6 +227,15 @@
       (specify "view transition on true"
         (patch-vt-true-test d*/patch-elements! div-element div-data)))
 
+    (describe "handles view-transitions selector"
+      (specify "no view transition selector when no view transition."
+        (patch-vt-false-vtsel-test d*/patch-elements! div-element div-data))
+
+      (specify "no view transitions selector when selector empty"
+        (patch-vt-true-vtsel-empty-test d*/patch-elements! div-element div-data))
+
+      (specify "view transitions selector when view transitions true and selector"
+        (patch-vt-true-vtsel-test d*/patch-elements! div-element div-data)))
 
     (describe "handles namespaces"
       (specify "no ns on default value"
@@ -219,6 +248,8 @@
 
 
 (comment
+  (patch-vt-true-vtsel-test d*/patch-elements! div-element div-data)
+  (d*/patch-elements! (at/->sse-gen) div-element {d*/use-view-transition true d*/view-transition-selector "#selector"})
   (ltr/run-test-var #'test-patch-elements!))
 
 ;; -----------------------------------------------------------------------------
@@ -252,6 +283,16 @@
         (patch-vt-non-bool-test d*/patch-elements-seq! multi-elements multi-data))
       (specify "view transition on true"
         (patch-vt-true-test d*/patch-elements-seq! multi-elements multi-data)))
+
+    (describe "handles view-transitions selectors"
+      (specify "no view transition selector when no view transition."
+        (patch-vt-false-vtsel-test d*/patch-elements-seq! multi-elements multi-data))
+
+      (specify "no view transitions selector when selector empty"
+        (patch-vt-true-vtsel-empty-test d*/patch-elements-seq! multi-elements multi-data))
+
+      (specify "view transitions selector when view transitions true and selector"
+        (patch-vt-true-vtsel-test d*/patch-elements-seq! multi-elements multi-data)))
 
     (describe "handles namespaces"
       (specify "no ns on default value"


### PR DESCRIPTION
I added support of the  new `view-transition-selector` option that comes with Datastar v1.0.2.
I also updated the CDN url provided by the SDK to that new version of Datastar.

Cheers,